### PR TITLE
Add cleanup instructions for the Grfana Helm test.

### DIFF
--- a/getting-started/installation-guide.md
+++ b/getting-started/installation-guide.md
@@ -195,7 +195,13 @@ Use the following command to run a set of Helm tests to help validate a new inst
 helm test <release> --namespace <namespace>
 ```
 
-This command deploys a series of pods that each perform a validation test on the cluster. If the test passes, the command deletes all deployed pods. If a test fails, deployed pods remain in place so you can inspect the pod log.
+This command deploys a series of pods that each perform a validation test on the cluster. This operation will run for several minutes before displaying results. If the tests pass, the command deletes most deployed pods. If a test fails, deployed pods remain in place so you can inspect the pod log.
+
+A test provided by Grafana is not automatically deleted. Delete it manually by running the following command.
+
+```bash
+ kubectl delete pod <release>-dashboardhost-test --namespace <namespace>
+```
 
 Navigate to the UI hostname you configured to login to SystemLink Enterprise as the configured system administrator.
 


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/install-systemlink-enterprise/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

I discovered yesterday that a test from the third-party Grafana Helm chart is not cleaning up automatically. Until we can upstream a fix for this issue, documenting steps to clean up the test manually.

Also added some text to inform the user that the test command runs silently for several minutes. It's easy to think that it has hung.

### Why should this Pull Request be merged?

Failing to cleanup the test pod could cause issues with autoscaling of Grafana containers.

### What testing has been done?

Verified on Rancher.
