### PR TITLE
Remove cleanup step for Grafana test

### DIFF
--- a/getting-started/installation-guide.md
+++ b/getting-started/installation-guide.md
@@ -182,12 +182,6 @@ helm test <release> --namespace <namespace>
 
 This command deploys a series of pods that each perform a validation test on the cluster. This operation will run for several minutes before displaying results. If the tests pass, the command deletes most deployed pods. If a test fails, deployed pods remain in place so you can inspect the pod log.
 
-A test provided by Grafana is not automatically deleted. Delete it manually by running the following command.
-
-```bash
- kubectl delete pod <release>-dashboardhost-test --namespace <namespace>
-```
-
 Navigate to the UI hostname you configured to login to SystemLink Enterprise as the configured system administrator.
 
 ## 6. Updating the Application


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/install-systemlink-enterprise/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

The Grafana test issue was fixed today. Removing the extra cleanup step.

### Why should this Pull Request be merged?

Removes unnecessary step.

### What testing has been done?

I'm waiting on pipeline runs to verify this fix. Will verify before committing.
