### PR TITLE
Temporarily adjust TestMonitor service resources.

### DIFF
--- a/getting-started/templates/systemlink-values.yaml
+++ b/getting-started/templates/systemlink-values.yaml
@@ -212,6 +212,15 @@ testmonitorservice:
       ## The Certificate key to be retrieved from existing ConfigMap
       ##
       certificateSubPath: *postgresCertificateFileName
+  ## Update default resource requests when deploying with a remote PostgresSQL database
+  ##
+  resources:
+    limits:
+      cpu: 200m
+      memory: 512Mi
+    requests:
+      cpu: 125m
+      memory: 320Mi
 
 ## Configuration for the Grafana dashboard provider.
 ##


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/install-systemlink-enterprise/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Current defaults in the test monitor package are too small for release usage. Increase usage in the values template.

### Why should this Pull Request be merged?

Works around bad pod behavior due to insufficient resource allocation.

### What testing has been done?

Verified on Rancher.
