### PR TITLE
Revert "Temporarily adjust TestMonitor service resources. (#25)"

### DIFF
--- a/getting-started/templates/systemlink-values.yaml
+++ b/getting-started/templates/systemlink-values.yaml
@@ -212,15 +212,6 @@ testmonitorservice:
       ## The Certificate key to be retrieved from existing ConfigMap
       ##
       certificateSubPath: *postgresCertificateFileName
-  ## Update default resource requests when deploying with a remote PostgresSQL database
-  ##
-  resources:
-    limits:
-      cpu: 200m
-      memory: 512Mi
-    requests:
-      cpu: 125m
-      memory: 320Mi
 
 ## Configuration for the Grafana dashboard provider.
 ##


### PR DESCRIPTION
This reverts commit ba788b612840d52d1ecc915d53c5188a70963c42.

- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/install-systemlink-enterprise/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Reverts temporary change to override test monitor defaults

### Why should this Pull Request be merged?

No longer needed in the next release. Should use the chart defaults. 

### What testing has been done?

N/A
