### PR TITLE
Updated create administrator value references

### DIFF
--- a/getting-started/configure-authentication.md
+++ b/getting-started/configure-authentication.md
@@ -25,14 +25,14 @@ After registration, you should have a `client id` and `client secret` value for 
 
 By default, a user who logs into SystemLink Enterprise will have minimal permissions and will not be able to make changes to the system. At installation, you must assign an initial administrator by defining a mapping for a specific Open ID Connect claim. The administrator will be able to log in, perform initial configuration of the application, and assign roles to other users.
 
-1. In systemlink-values.yaml, set `initialAdministratorMapping.mappingKey` to the claim to use. The default is "email".
-2. Set `initialAdministratorMapping.mappingValue` to the value that identifies the administrator.
+1. In systemlink-values.yaml, set `userservicesetup.initialAdministratorMapping.mappingKey` to the claim to use. The default is "email".
+2. Set `userservicesetup.initialAdministratorMapping.mappingValue` to the value that identifies the administrator.
 
     For example, set the value to "john.doe@myorganization.org" to make the user with that email address the initial system administrator.
 
 If you configure a mapping that applies to multiple users, all selected users will have administrator access to the cluster.
 
-Normally, you configure the administrator mapping only at install but you can assign an administrator during an upgrade by setting the `initialAdministratorMapping.createOnUpgrade` value to true.
+Normally, you configure the administrator mapping only at install but you can assign an administrator during an upgrade by setting the `userservicesetup.initialAdministratorMapping.createOnUpgrade` value to true.
 
 After the initial install, use the SystemLink Enterprise application for all future user management. NI recommends removing the mapping configuration from systemlink-values.yaml once the application is working to avoid accidentally re-applying an unwanted mapping in the future.
 


### PR DESCRIPTION
- [ ] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/install-systemlink-enterprise/blob/master/CONTRIBUTING.md).

Once the create administrator job is moved into a separate Helm chart from the SLE chart, the way we reference the admin mapping values will change. This PR documents those changes.

### What does this Pull Request accomplish?

Updates documentation around the initial admin mapping.

### Why should this Pull Request be merged?

Once the SLE Helm chart pulls in the new admin creation Helm chart, current top-level values.yaml files will be wrong. This documents the change.

### What testing has been done?

N/A
