### PR TITLE
Expose fileingestion.rateLimits.upload value

### DIFF
--- a/getting-started/templates/systemlink-values.yaml
+++ b/getting-started/templates/systemlink-values.yaml
@@ -508,7 +508,9 @@ fileingestion:
     ## S3 Port
     ##
     port: *minioPort
-  ## Configure rate limiting per user per replica over one second.
+   ## Configure rate limiting. Limits are enforced per-user.  Each replica of the file ingestion service 
+   ## applies its own per-user limit. With load-balancing, the effective rate will be higher than the 
+   ## individual rates configured here. 
   ##
   rateLimits:
     ## Upload file

--- a/getting-started/templates/systemlink-values.yaml
+++ b/getting-started/templates/systemlink-values.yaml
@@ -508,6 +508,12 @@ fileingestion:
     ## S3 Port
     ##
     port: *minioPort
+  ## Configure rate limiting per user per replica over one second.
+  ##
+  rateLimits:
+    ## Upload file
+    ##
+    upload: 3
 
 ## Configuration for JupyterHub
 ##


### PR DESCRIPTION
Users might want to customize how many files can be uploaded by a single user over a period of one second. This limit applies per replica (currently there are between 2 and 10 replicas by default).

Example use-cases could be the ability to (temporarily) migrate large amounts of data, or permanently allowing users to upload a lot of files from the frontend.

- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/install-systemlink-enterprise/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Expose the `fileingestion.rateLimits.upload` value. 

### Why should this Pull Request be merged?

Expose this value so that it can be changed on-demand

### What testing has been done?

N/A
