### PR TITLE
Document special format requirements for encryption key secrets

### DIFF
--- a/getting-started/secrets.md
+++ b/getting-started/secrets.md
@@ -19,9 +19,9 @@ The secrets listed in this document are required. Unless otherwise specified, al
 |Whitelisted API Key Hashes|||
 ||userservices-apikey-whitelist|Manages the list of authorized whitelisted API keys. This secret contains a single field. <br/><ul><li>`whitelistedApiKeyHashes`: An array of hexadecimal-encoded SHA-512 hashes, separated by commas, with no whitespace or trailing delimiter.</li></ul>
 |Encryption Keys|||
-||fileingestionservices-encryption-key| Field: encryptionKey<br/>Key Type: AES-256|
+||fileingestionservices-encryption-key| Field: encryptionKey<br/>Key Type: AES-256<br/>Notes: The key value must be Base64 encoded.|
 ||systemsmanagementservice-dataprotection|Field: aesKey<br/>Key Type: AES-128|
-||webappservices-continuation-token|Field: encryptionKey<br/>Key Type: AEAD|
+||webappservices-continuation-token|Field: encryptionKey<br/>Key Type: AEAD<br/>Notes: The key value must be Base64 encoded.|
 ||webserver-session|Field: encryptionKey<br/>Key Type: AES-128<br/>Field: signatureKey<br/>Key Type: SHA-256|
 |Dremio Credentials|||
 ||nidataframe-dremio-credentials|Has the following fields.<ul><li>`username`: A username used to access the Dremio instance.</li><li>`password`: A password used to access the Dremio instance.</li></ul>|

--- a/getting-started/templates/systemlink-secrets.yaml
+++ b/getting-started/templates/systemlink-secrets.yaml
@@ -189,7 +189,7 @@ dataframeservice:
 ##
 fileingestion:
   secrets:
-    ## Cryptographic key to be used for AES-256 encryption of data at rest. This key should have a length of 32 bytes.
+    ## Cryptographic key to be used for AES-256 encryption of data at rest. This key should have a length of 32 bytes. The key value must be Base64 encoded.
     ##
     encryptionKey: ""  # <ATTENTION>
     ## Access key information for S3/MinIO access.
@@ -308,6 +308,6 @@ webappservices:
       ## Refer to the MongoDB documentation for key generation: https://www.mongodb.com/docs/manual/tutorial/enforce-keyfile-access-control-in-existing-replica-set/#create-a-keyfile
       ##
       replicaSetKey: ""  # <ATTENTION>
-    ## Key used to encrypt continuation tokens produced by the API. This is an AEAD key with a length of 256 bits.
+    ## Key used to encrypt continuation tokens produced by the API. This is an AEAD key with a length of 32 bytes. The key value must be Base64 encoded.
     ##
     continuationTokenEncryptionKey: ""  # <ATTENTION>


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/install-systemlink-enterprise/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

The Elixir services require secrets to be Base64 encoded. Documenting that requirement. I was tempted to make this standard for all secrets for simplicity, but it's not really correct to enforce this in cases where the user of the secret won't first decode back to binary.

### Why should this Pull Request be merged?

This caused confusion internally and could cause confusion to future customers as well.

### What testing has been done?

N/A
