### PR TITLE
Add nisession Whitelisted API Keys

### DIFF
--- a/getting-started/secrets.md
+++ b/getting-started/secrets.md
@@ -16,6 +16,7 @@ The secrets listed in this document are required. Unless otherwise specified, al
 ||saltmaster-init-apikey||
 ||systemsmamagement-service-apikey||
 ||webserver-apikey||
+||nisession-apikey||
 |Whitelisted API Key Hashes|||
 ||userservices-apikey-whitelist|Manages the list of authorized whitelisted API keys. This secret contains a single field. <br/><ul><li>`whitelistedApiKeyHashes`: An array of hexadecimal-encoded SHA-512 hashes, separated by commas, with no whitespace or trailing delimiter.</li></ul>
 |Encryption Keys|||

--- a/getting-started/templates/systemlink-secrets.yaml
+++ b/getting-started/templates/systemlink-secrets.yaml
@@ -114,6 +114,9 @@ userservices:
         - serviceName: "webserver"
           key: ""
           hash: "<SHA512 hash of key>"
+        - serviceName: "nisession"
+          key: ""
+          hash: "<SHA512 hash of key>"
 
 ## Secret configuration for Asset Management
 ##


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/install-systemlink-enterprise/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

These changes address the need to add the Session Manager services (nisession) to the lists of Whitelisted API Keys in both secrets.md and systemlink-secrets.yaml.  These changes are tracked by [Task 1946372](https://ni.visualstudio.com/DevCentral/_workitems/edit/1946372)

### Why should this Pull Request be merged?

It's needed for service operation.

### What testing has been done?

N/A
