### PR TITLE
Document generic artifact secret

### DIFF
--- a/getting-started/secrets.md
+++ b/getting-started/secrets.md
@@ -6,6 +6,8 @@ The secrets listed in this document are required. Unless otherwise specified, al
 |--|--|--|
 |Image Pull||The NI container repository that hosts SystemLink Enterprise is private and requires authenticated access. You will have received credentials with access to SystemLink Enterprise. Configure image pull secrets for SystemLink Enterprise using the `global.imagePullSecrets` array in _systemlink-values.yaml_. <br/><br/>Image pull secrets must conform to the [kubernetes.io/dockerconfigjson format](https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/).|
 ||niartifacts-secret||
+|Generic artifact pull|||
+||niartifacts-generic|Some SystemLink Enterprise services require miscellaneous artifacts that aren't container-based. These are hosted in the same NI repository as the Docker images and have the same authentication. This secret is configured in the `global.genericArtifactPullSecret` field, and contains the following fields: <br/><ul><li>`url`: The URL with the subpath containing generic artifacts.</li><li>`user`: Will reuse the user from 'niartifacts-secret'</li><li>`password`: Will reuse the password from 'niartifacts-secret'</li></ul>|
 |Authentication|||
 ||oidc-secret|Identifies SystemLink Enterprise with your OpenID Connect authentication provider and has the following fields. <br/><ul><li>`clientId`: An OpenID Connect client ID.</li><li>`clientSecret`: The secret corresponding to `clientId`.</li><li>`jwks`: A JSON web key set. If none is required, set to an empty string value.</li></ul>|
 |Whitelisted API Keys|||

--- a/getting-started/templates/systemlink-secrets.yaml
+++ b/getting-started/templates/systemlink-secrets.yaml
@@ -17,10 +17,10 @@ secrets:
     deploySecret: true
     ## User for repository access. This information will have been provided with the application.
     ##
-    user: "" # <ATTENTION>
+    user: &imageRegistryUser "" # <ATTENTION>
     ## Password for repository access. This information will have been provided with the application.
     ##
-    password: ""  # <ATTENTION>
+    password: &imageRegistryPass ""  # <ATTENTION>
   # MinIO block storage credentials.
   minio:
     ## User for MinIO access. This default can be used if desired.
@@ -43,13 +43,13 @@ secrets:
   genericArtifactPull:
     ## URL for the repository.
     ##
-    url: "" # <ATTENTION>
-    ## User for repository access. This information will have been provided with the application.
+    url: "https://niedge01.jfrog.io/ni-generic" # <ATTENTION> - Override if mirroring the SystemLink container registry.
+    ## User for repository access. This will be the same as the image pull credentials.
     ##
-    user: "" # <ATTENTION>
-    ## Password for repository access. This information will have been provided with the application.
+    user: *imageRegistryUser
+    ## Password for repository access. This will be the same as the image pull credentials.
     ##
-    password: "" # <ATTENTION>
+    password: *imageRegistryPass
 
 ## Secret configuration for the SystemLink web application.
 ##

--- a/getting-started/templates/systemlink-secrets.yaml
+++ b/getting-started/templates/systemlink-secrets.yaml
@@ -38,13 +38,17 @@ secrets:
     ## This cookie is used to authenticate containers in the RabbitMQ stateful set. Use a strong random sequence of characters.
     ##
     erlangCookie: ""  # <ATTENTION>
-  # Miscellaneous artifact repository credentials.
+  ## Miscellaneous artifact repository credentials.
+  ##
   genericArtifactPull:
-    # URL for the repository.
+    ## URL for the repository.
+    ##
     url: "" # <ATTENTION>
-    # User for repository access. This information will have been provided with the application.
+    ## User for repository access. This information will have been provided with the application.
+    ##
     user: "" # <ATTENTION>
-    # Password for repository access. This information will have been provided with the application.
+    ## Password for repository access. This information will have been provided with the application.
+    ##
     password: "" # <ATTENTION>
 
 ## Secret configuration for the SystemLink web application.

--- a/getting-started/templates/systemlink-secrets.yaml
+++ b/getting-started/templates/systemlink-secrets.yaml
@@ -20,7 +20,7 @@ secrets:
     user: &imageRegistryUser "" # <ATTENTION>
     ## Password for repository access. This information will have been provided with the application.
     ##
-    password: &imageRegistryPass ""  # <ATTENTION>
+    password: &imageRegistryPassword ""  # <ATTENTION>
   # MinIO block storage credentials.
   minio:
     ## User for MinIO access. This default can be used if desired.
@@ -49,7 +49,7 @@ secrets:
     user: *imageRegistryUser
     ## Password for repository access. This will be the same as the image pull credentials.
     ##
-    password: *imageRegistryPass
+    password: *imageRegistryPassword
 
 ## Secret configuration for the SystemLink web application.
 ##

--- a/getting-started/templates/systemlink-secrets.yaml
+++ b/getting-started/templates/systemlink-secrets.yaml
@@ -38,6 +38,14 @@ secrets:
     ## This cookie is used to authenticate containers in the RabbitMQ stateful set. Use a strong random sequence of characters.
     ##
     erlangCookie: ""  # <ATTENTION>
+  # Miscellaneous artifact repository credentials.
+  genericArtifactPull:
+    # URL for the repository.
+    url: "" # <ATTENTION>
+    # User for repository access. This information will have been provided with the application.
+    user: "" # <ATTENTION>
+    # Password for repository access. This information will have been provided with the application.
+    password: "" # <ATTENTION>
 
 ## Secret configuration for the SystemLink web application.
 ##

--- a/getting-started/templates/systemlink-values.yaml
+++ b/getting-started/templates/systemlink-values.yaml
@@ -22,6 +22,10 @@ global:
   # <ATTENTION> - Use this override if mirroring the SystemLink container registry.
   ##
   ## imageRegistry: "niedge01.jfrog.io/ni-docker"
+  ##
+  ## Defines a secret containing the credentials for a repo hosting miscellaneous artifacts
+  ##
+  genericArtifactPullSecret: "niartifacts-generic"
   ## Ingress settings that apply globally.
   # <ATTENTION> - Use the following section to apply annotation-based configuration to all Systemlink ingresses.
   #    Configuration is specific to the ingress controller, and the defaults will be sufficient for many deployments.


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/install-systemlink-enterprise/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Document the changes introduced in [this PR](https://dev.azure.com/ni/DevCentral/_git/Skyline/pullrequest/301581). Installing our custom Grafana plugins requires hosting some .zip file artifacts, so we needed to add the concept of a generic artifact repo. In practice, this will be same as the Artifactory instance used for Docker images, but requires a new secret due to the limitations of the image pull secret.

### Why should this Pull Request be merged?

This will be required for successful deployment of Grafana.

### What testing has been done?

N/A