### PR TITLE
Add dashboardhost whitelisted API key

### DIFF
--- a/getting-started/secrets.md
+++ b/getting-started/secrets.md
@@ -19,6 +19,7 @@ The secrets listed in this document are required. Unless otherwise specified, al
 ||systemsmamagement-service-apikey||
 ||webserver-apikey||
 ||nisession-apikey||
+||dashboardhost-apikey||
 |Whitelisted API Key Hashes|||
 ||userservices-apikey-whitelist|Manages the list of authorized whitelisted API keys. This secret contains a single field. <br/><ul><li>`whitelistedApiKeyHashes`: An array of hexadecimal-encoded SHA-512 hashes, separated by commas, with no whitespace or trailing delimiter.</li></ul>
 |Encryption Keys|||

--- a/getting-started/templates/systemlink-secrets.yaml
+++ b/getting-started/templates/systemlink-secrets.yaml
@@ -129,6 +129,9 @@ userservices:
         - serviceName: "nisession"
           key: ""
           hash: "<SHA512 hash of key>"
+        - serviceName: "dashboardhost"
+          key: ""
+          hash: "<SHA512 hash of key>"
 
 ## Secret configuration for Asset Management
 ##


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/install-systemlink-enterprise/blob/master/CONTRIBUTING.md).


### What does this Pull Request accomplish?

Adds documentation and an entry for the whitelisted API key for the dashboard host service (Grafana).

### Why should this Pull Request be merged?

This will be necessary for implementing RBAC control in Grafana.

### What testing has been done?

N/A