### PR TITLE
Uncomment global registry override

### DIFF
--- a/getting-started/templates/systemlink-values.yaml
+++ b/getting-started/templates/systemlink-values.yaml
@@ -21,7 +21,7 @@ global:
   ## Overrides the default image registry.
   # <ATTENTION> - Use this override if mirroring the SystemLink container registry.
   ##
-  ## imageRegistry: "niedge01.jfrog.io/ni-docker"
+  imageRegistry: "niedge01.jfrog.io/ni-docker"
   ##
   ## Defines a secret containing the credentials for a repo hosting miscellaneous artifacts
   ##


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/install-systemlink-enterprise/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

I want to ensure we consistently use niedge01 by default.

### Why should this Pull Request be merged?

Fixes default.

### What testing has been done?

N/A
