### PR TITLE
Disable dashboardhost RBAC support by default for now.

### DIFF
--- a/getting-started/templates/systemlink-values.yaml
+++ b/getting-started/templates/systemlink-values.yaml
@@ -237,6 +237,13 @@ testmonitorservice:
 ## Configuration for the Grafana dashboard provider.
 ##
 dashboardhost:
+  ## Mirror SystemLink RBAC onto Grafana using a repeating job
+  ##
+  accessControlMirroring:
+    ## Enable RBAC mirroring.
+    ##
+    enabled: false
+
   ## Name to use for the database access secret.
   ##
   databaseSecretName: &dashboardhostdbSecret "dashboardhost-postgres-secrets"


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/install-systemlink-enterprise/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

This feature is not yet supported and needs to be explicitly toggled off.

### Why should this Pull Request be merged?

Disables incomplete feature.

### What testing has been done?

Test deployment.
