### PR TITLE
Override upload limit defaults for services that support uploads

### DIFF
--- a/getting-started/templates/systemlink-values.yaml
+++ b/getting-started/templates/systemlink-values.yaml
@@ -516,6 +516,14 @@ saltmaster:
 ## File upload configuration.
 ##
 fileingestion:
+  ## Ingress configuration
+  ##
+  ingress:
+    ## Override the default upload limit for an nginx ingress controller.
+    ##
+    annotations:
+      nginx.ingress.kubernetes.io/proxy-body-size: 2000m
+
   ## Configure S3/MinIO access.
   ##
   s3:
@@ -555,6 +563,14 @@ fileingestion:
 sl-jupyterhub:
   jupyterhub:
     imagePullSecrets: *pullSecrets
+
+  ## Ingress configuration.
+  ##
+  ingress:
+    ## Override the default upload limit for an nginx ingress controller.
+    ##
+    annotations:
+      nginx.ingress.kubernetes.io/proxy-body-size: 100m
 
 ## Configuration for Notebook Execution workers
 ##


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/install-systemlink-enterprise/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

The default nginx upload limit is around 2Mb. Increase the default for services that support file uploads.

### Why should this Pull Request be merged?

Fixes issues with upload sizes being limited.

### What testing has been done?

Test deployment.
