### PR TITLE
Add new registry value for the image pull secret configuration

### DIFF
--- a/getting-started/templates/systemlink-secrets.yaml
+++ b/getting-started/templates/systemlink-secrets.yaml
@@ -15,6 +15,9 @@ secrets:
     ##
     # <ATTENTION> - Disable if the container repository credentials are configured elsewhere.
     deploySecret: true
+    ##  The registry to which this secret applies. Ignored if global.imageRegistry is set.
+    ##
+    registry: ""
     ## User for repository access. This information will have been provided with the application.
     ##
     user: &imageRegistryUser "" # <ATTENTION>


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/install-systemlink-enterprise/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

I added a way to set the image registry for the image pull secret without requiring the global registry. Add that value to our templates.

### Why should this Pull Request be merged?

Really just for completeness. Our configuration here uses the global registry.

### What testing has been done?

Tested various dry run deployment scenarios.
