### PR TITLE
Updated the serviceName for the SessionManager service

### DIFF
--- a/getting-started/templates/systemlink-secrets.yaml
+++ b/getting-started/templates/systemlink-secrets.yaml
@@ -123,7 +123,7 @@ userservices:
         - serviceName: "saltmaster-init"
           key: ""
           hash: "<SHA512 hash of key>"
-        - serviceName: "sessionmanagerservice"
+        - serviceName: "sessionmanager"
           key: ""
           hash: "<SHA512 hash of key>"
         - serviceName: "systemsmanagement-service"


### PR DESCRIPTION
Updated the `serviceName` property for the SessionManager service to match the changes made elsewhere.

- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/install-systemlink-enterprise/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Updates the internal name of the Session Manager service to "sessionmanager".

### Why should this Pull Request be merged?

So that the documentation matches the service name.

### What testing has been done?

N/A
