### PR TITLE
Install Grafana plugin using correct URL

### DIFF
--- a/getting-started/templates/systemlink-values.yaml
+++ b/getting-started/templates/systemlink-values.yaml
@@ -357,7 +357,7 @@ dashboardhost:
     ## https://grafana.com/docs/grafana/latest/installation/docker/#install-plugins-from-other-sources
     ##
     plugins:
-      - https://github.com/ni/systemlink-notebook-datasource/releases/latest/download/systemlink-notebook-datasource.zip;ni-slnotebook-datasource
+      - http://localhost:8080/ni/plugins/systemlink-notebook-datasource/1.1.0.zip;ni-slnotebook-datasource
 
     ## Customize the grafana.ini file.
     ##


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/install-systemlink-enterprise/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

#42 documented a change in how we install our custom plugins for Grafana, but the plugin URL in the values template wasn't updated to reflect this.

### Why should this Pull Request be merged?

Necessary to install Grafana successfully.

### What testing has been done?

n/a