### PR TITLE
Clarify that s3.port must be configured if not using the SLE MinIO

### DIFF
--- a/getting-started/templates/systemlink-values.yaml
+++ b/getting-started/templates/systemlink-values.yaml
@@ -464,6 +464,7 @@ dataframeservice:
     ##
     service: *minioServiceName
     ## S3 port number.
+    # <ATTENTION> This must be overridden if not using the SLE MinIO instance.
     ##
     port: *minioPort
   ## Configure Dremio access
@@ -549,6 +550,7 @@ fileingestion:
     ##
     service: *minioServiceName
     ## S3 Port
+    # <ATTENTION> This must be overridden if not using the SLE MinIO instance.
     ##
     port: *minioPort
    ## Configure rate limiting. Limits are enforced per-user.  Each replica of the file ingestion service 


### PR DESCRIPTION
- [X] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/install-systemlink-enterprise/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

We have a bug [here](https://dev.azure.com/ni/DevCentral/_workitems/edit/1954334) stating that the installation guide needs to provide better instructions if the customer is using their own S3 or MinIO instance, rather than the MinIO instance deployed with SLE by default. To make this more clear, I added `<ATTENTION>` blocks to the places where we reference the MinIO deployment's port number, stating that the port will need to be changed if the user is using a different S3 or MinIO instance.

I think a more complete fix requires a change to the installation guide, as it should call out what needs to be done if the user is not using the SLE-provided MinIO instance. I'll work with @MelissaHilliard on this, as the guide no longer lives in our GitHub repo.

### What testing has been done?

None.