### PR TITLE
Update Kafka operator admin-values

### DIFF
--- a/getting-started/templates/systemlink-admin-values.yaml
+++ b/getting-started/templates/systemlink-admin-values.yaml
@@ -11,3 +11,9 @@ strimzi-kafka-operator:
   watchAnyNamespace: true
   podSecurityContext: 
     runAsNonRoot: true
+  ## Clusters that are not allowing external intenet access MUST set properties below.
+  ## More information on the properties can be found at: https://artifacthub.io/packages/helm/strimzi/strimzi-kafka-operator
+  defaultImageRegistry:
+  image:
+    imagePullSecrets:
+  

--- a/getting-started/templates/systemlink-admin-values.yaml
+++ b/getting-started/templates/systemlink-admin-values.yaml
@@ -13,7 +13,11 @@ strimzi-kafka-operator:
     runAsNonRoot: true
   ## Clusters that are not allowing external intenet access MUST set properties below.
   ## More information on the properties can be found at: https://artifacthub.io/packages/helm/strimzi/strimzi-kafka-operator
-  defaultImageRegistry:
+  defaultImageRegistry: "" # <ATTENTION>
+  ## The registry where you image is stored.
+  ##
   image:
-    imagePullSecrets:
+    imagePullSecrets: "" # <ATTENTION>
+    ## The secret for the registry that your operator image is stored in.
+    ##
   


### PR DESCRIPTION
Basing off of issues faced by GM.

https://ni.visualstudio.com/DevCentral/_boards/board/t/ASW%20SystemLink%20NIC%202/Work%20Items/?workitem=2061988

- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/install-systemlink-enterprise/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Lets the user know that if they cannot reach an external network then they will need to specify the proper values to point towards their operator image.

### Why should this Pull Request be merged?

So users like GM do not run into this in the future.

### What testing has been done?

Testing has been done with GMs deployment.
