### PR TITLE
Add Dremio distributed storage configuration to systemlink-values.yaml

### DIFF
--- a/getting-started/templates/systemlink-secrets.yaml
+++ b/getting-started/templates/systemlink-secrets.yaml
@@ -214,6 +214,18 @@ dataframeservice:
       ## The password for the Dremio instance.
       ##
       password: ""  # <ATTENTION>
+  sldremio:
+    # Dremio distributed storage configuration. This must be configured for the service to perform acceptably.
+    # See https://github.com/dremio/dremio-cloud-tools/blob/master/charts/dremio_v2/docs/Values-Reference.md#distributed-storage-values
+    # Configure this section as appropriate for your environment. The configuration below
+    # assumes the service is being connected to Amazon S3 or an equivalent, like MinIO.
+    # Note: this only partially configures distributed storage. See the rest of the configuration in
+    # systemlink-values.yaml under dataframeservice.sldremio.distStorage.
+    distStorage:
+      aws: # <ATTENTION> - change if not using Amazon S3 or an equivalent
+        credentials:
+          accessKey: *minioUser # <ATTENTION> - change if not using MinIO
+          secret: *minioPassword # <ATTENTION> - change if not using MinIO
 
 ## Secret configuration for file uploads.
 ##

--- a/getting-started/templates/systemlink-values.yaml
+++ b/getting-started/templates/systemlink-values.yaml
@@ -513,10 +513,6 @@ dataframeservice:
         bucketName: *dataframeBucket
         path: "/dremio/distStorage"
         authentication: "accessKeySecret"
-        # <ATTENTION> - Configure credentials in systemlink-secrets.yaml under sldremio.distStorage.aws.credentials
-        # credentials:
-        #   accessKey: ""
-        #   secret: ""
         # extraProperties are only necessary if not using Amazon S3
         # <ATTENTION>: If using Amazon S3, comment out extraProperties. If using MinIO or an equivalent, set fs.s3a.endpoint
         # to the FQDN of MinIO or the equivalent service.
@@ -540,6 +536,7 @@ dataframeservice:
             <description>Value can either be true or false, set to true to use SSL with a secure Minio server.</description>
             <value>false</value>
           </property>
+
   ## Configure Kafka access
   ##
   kafkaconnect:

--- a/getting-started/templates/systemlink-values.yaml
+++ b/getting-started/templates/systemlink-values.yaml
@@ -459,7 +459,7 @@ dataframeservice:
       secretName: "nidataframe-s3-credentials"
     ## The name of the S3 or MinIO bucket that the service should connect to.
     ##
-    bucket: "systemlink-dataframe"
+    bucket: &dataframeBucket "systemlink-dataframe"
     ## This should just be the name of the scheme, without the trailing ://.
     ##
     schemeName: "http"
@@ -503,6 +503,43 @@ dataframeservice:
       ## The name of the key in the above secret whose value contains the Dremio password
       ##
       passwordKey: "password"
+    distStorage:
+      # Dremio distributed storage configuration. This must be configured for the service to perform acceptably.
+      # See https://github.com/dremio/dremio-cloud-tools/blob/master/charts/dremio_v2/docs/Values-Reference.md#distributed-storage-values
+      # <ATTENTION>: This only partially configures distributed storage. Credentials must be configured in systemlink-secrets.yaml under
+      # sldremio.distStorage.aws.credentials.
+      type: "aws" # <ATTENTION> - change this if not using Amazon S3 or an equivalent, like MinIO
+      aws:
+        bucketName: *dataframeBucket
+        path: "/dremio/distStorage"
+        authentication: "accessKeySecret"
+        # <ATTENTION> - Configure credentials in systemlink-secrets.yaml under sldremio.distStorage.aws.credentials
+        # credentials:
+        #   accessKey: ""
+        #   secret: ""
+        # extraProperties are only necessary if not using Amazon S3
+        # <ATTENTION>: If using Amazon S3, comment out extraProperties. If using MinIO or an equivalent, set fs.s3a.endpoint
+        # to the FQDN of MinIO or the equivalent service.
+        extraProperties: |
+          <property>
+            <name>fs.s3a.endpoint</name>
+            <value><ATTENTION> - set to the FQDN of the S3 endpoint</value>
+          </property>
+          <property>
+            <name>fs.s3a.path.style.access</name>
+            <description>Value has to be set to true.</description>
+            <value>true</value>
+          </property>
+          <property>
+            <name>dremio.s3.compat</name>
+            <description>Value has to be set to true.</description>
+            <value>true</value>
+          </property>
+          <property>
+            <name>fs.s3a.connection.ssl.enabled</name>
+            <description>Value can either be true or false, set to true to use SSL with a secure Minio server.</description>
+            <value>false</value>
+          </property>
   ## Configure Kafka access
   ##
   kafkaconnect:


### PR DESCRIPTION
- [X] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/install-systemlink-enterprise/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Per the Dremio [docs](https://raw.githubusercontent.com/dremio/dremio-cloud-tools/master/charts/dremio_v2/docs/setup/Important-Setup-Considerations.md#:~:text=*%20%60distStorage.type%60%3A%20By%20default%2C%20the%20%60distStorage.type%60%20is%20set%20to%20%60local%60.%20This%20**must**%20be%20changed%20prior%20to%20production%20use.%20We%20do%20not%20recommend%20users%20use%20local%20distributed%20storage%20as%20part%20of%20a%20production%20setup.), distributed storage must be configured in production deployments of Dremio, as it greatly increases performance. This change reminds customers to configure it, attempts to guide them, and offers pointers for connecting to MinIO. I also plan to work with @MelissaHilliard on some installation guide updates related to this change.

### Why should this Pull Request be merged?

This makes it easier for customers to turn on distributed storage.

### What testing has been done?

We use this configuration to turn on distributed storage in the umbrella chart deployment of the DFS to Rancher.