### PR TITLE
Change nbexecworker to nbexec-argo-workflow in whitelisted api keys

### DIFF
--- a/getting-started/templates/systemlink-secrets.yaml
+++ b/getting-started/templates/systemlink-secrets.yaml
@@ -120,7 +120,7 @@ userservices:
       - serviceName: "jupyterhub"
         key: ""
         hash: "<SHA512 hash of key>"
-      - serviceName: "nbexecworker"
+      - serviceName: "nbexec-argo-workflow"
         key: ""
         hash: "<SHA512 hash of key>"
       - serviceName: "saltmaster-init"


### PR DESCRIPTION
Nbexecworker apikey was removed and instead nbexec-argo-wrofklow apikey was added.

