### PR TITLE
Add values for configuring Kafka operator Java heap size

### DIFF
--- a/getting-started/templates/systemlink-admin-values.yaml
+++ b/getting-started/templates/systemlink-admin-values.yaml
@@ -11,3 +11,9 @@ strimzi-kafka-operator:
   watchAnyNamespace: true
   podSecurityContext: 
     runAsNonRoot: true
+  ## Uncomment to set Java heap size
+  ## Only required if the operator is crashing with
+  ## "Terminating due to java.lang.OutOfMemoryError: Java heap space"
+  #extraEnvs:
+  #  - name: JAVA_OPTS
+  #    value: "-Xms256m -Xmx256m"


### PR DESCRIPTION
- [X] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/install-systemlink-enterprise/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Add example values that allow for configuring the Kafka operator Java heap size.

### Why should this Pull Request be merged?

This configuration might be required for customers that make heavy use of Kafka.

### What testing has been done?

This configuration was tested as part of the following change.
https://ni.visualstudio.com/DevCentral/_git/Skyline/pullrequest/360943
