### PR TITLE
Improve documentation for insecure flag in nbexecservice s3 configuration

### DIFF
--- a/getting-started/templates/systemlink-values.yaml
+++ b/getting-started/templates/systemlink-values.yaml
@@ -667,7 +667,7 @@ nbexecservice:
         # <ATTENTION> This must be overridden if not using the SLE MinIO instance.
         ##
         port: *minioPort
-        ## Set this value to true of an http (insecure) connection, or false for an https (secure) connection.
+        ## Set this value to true for an http (insecure) connection, or false for an https (secure) connection.
         ##
         insecure: true
         ## Secret PATH containing the credentials.

--- a/getting-started/templates/systemlink-values.yaml
+++ b/getting-started/templates/systemlink-values.yaml
@@ -667,7 +667,7 @@ nbexecservice:
         # <ATTENTION> This must be overridden if not using the SLE MinIO instance.
         ##
         port: *minioPort
-        ## Set this value to enable/disable insecure connection: http or https.
+        ## Set this value to true of an http (insecure) connection, or false for an https (secure) connection.
         ##
         insecure: true
         ## Secret PATH containing the credentials.


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/install-systemlink-enterprise/blob/master/CONTRIBUTING.md).

TODO: Check the above box with an 'x' indicating you've read and followed [CONTRIBUTING.md](https://github.com/ni/install-systemlink-enterprise/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Improves the description of the insecure flag

### Why should this Pull Request be merged?

Customer has complained the documentation is not clear enough

### What testing has been done?

N/A
