### PR TITLE
Clarify that the Dremio S3 endpoint config must include the port

### DIFF
--- a/getting-started/templates/systemlink-values.yaml
+++ b/getting-started/templates/systemlink-values.yaml
@@ -519,7 +519,7 @@ dataframeservice:
         extraProperties: |
           <property>
             <name>fs.s3a.endpoint</name>
-            <value><ATTENTION> - set to the FQDN of the S3 endpoint, including the port. Example: {svc-name}-{namespace}.svc.cluster.local:9000</value>
+            <value><ATTENTION> - set to the FQDN of the S3 endpoint, including the port, but without an HTTP or HTTPS prefix. Example: {svc-name}-{namespace}.svc.cluster.local:9000</value>
           </property>
           <property>
             <name>fs.s3a.path.style.access</name>

--- a/getting-started/templates/systemlink-values.yaml
+++ b/getting-started/templates/systemlink-values.yaml
@@ -519,7 +519,7 @@ dataframeservice:
         extraProperties: |
           <property>
             <name>fs.s3a.endpoint</name>
-            <value><ATTENTION> - set to the FQDN of the S3 endpoint</value>
+            <value><ATTENTION> - set to the FQDN of the S3 endpoint, including the port. Example: {svc-name}-{namespace}.svc.cluster.local:9000</value>
           </property>
           <property>
             <name>fs.s3a.path.style.access</name>


### PR DESCRIPTION
- [X] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/install-systemlink-enterprise/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

In a call with Matt and Brad, we found that the documentation for Dremio's S3 endpoint configuration was lacking. Specifically, we couldn't remember if the config was meant to include the port or not.

### Why should this Pull Request be merged?

This improves the documentation in our customer-facing values file.

### What testing has been done?

We tested this while deploying SLE to Brad's internal cluster.
