### PR TITLE
Clarify that the Grafana db must be created manually. Clarify distStorage URL

### DIFF
--- a/getting-started/templates/systemlink-values.yaml
+++ b/getting-started/templates/systemlink-values.yaml
@@ -386,7 +386,7 @@ dashboardhost:
         ##
         host: $__file{/etc/secrets/dashboardhost/host}
         ## The name of the Grafana database. Leave it set to grafana (default) or some other name.
-        ## <ATTENTION> - the database must be manually created ahead of time. If using
+        ## <ATTENTION> - You must create the database manually ahead of time. If you are using
         ## the default database name, a database named "grafana" must be created.
         # name: "database-name"
         ## Use either URL or the other fields above to configure the database.

--- a/getting-started/templates/systemlink-values.yaml
+++ b/getting-started/templates/systemlink-values.yaml
@@ -520,7 +520,7 @@ dataframeservice:
         extraProperties: |
           <property>
             <name>fs.s3a.endpoint</name>
-            <value><ATTENTION> - set to the FQDN of the S3 endpoint, including the port, but without an HTTP or HTTPS prefix. Example: {svc-name}-{namespace}.svc.cluster.local:9000</value>
+            <value><ATTENTION> - set to the FQDN of the S3 endpoint, including the port, but without an HTTP or HTTPS prefix. Example: {svc-name}.{namespace}.svc.cluster.local:9000</value>
           </property>
           <property>
             <name>fs.s3a.path.style.access</name>

--- a/getting-started/templates/systemlink-values.yaml
+++ b/getting-started/templates/systemlink-values.yaml
@@ -386,7 +386,8 @@ dashboardhost:
         ##
         host: $__file{/etc/secrets/dashboardhost/host}
         ## The name of the Grafana database. Leave it set to grafana (default) or some other name.
-        ##
+        ## <ATTENTION> - the database must be manually created ahead of time. If using
+        ## the default database name, a database named "grafana" must be created.
         # name: "database-name"
         ## Use either URL or the other fields above to configure the database.
         ## url: postgres://dashboardhost:abc123@dashboardhostpostgrescluster-primary.systemlink-nic2.svc:5432/grafana

--- a/getting-started/templates/systemlink-values.yaml
+++ b/getting-started/templates/systemlink-values.yaml
@@ -387,7 +387,7 @@ dashboardhost:
         host: $__file{/etc/secrets/dashboardhost/host}
         ## The name of the Grafana database. Leave it set to grafana (default) or some other name.
         ## <ATTENTION> - You must create the database manually ahead of time. If you are using
-        ## the default database name, a database named "grafana" must be created.
+        ## the default database name, you must create a database named "grafana".
         # name: "database-name"
         ## Use either URL or the other fields above to configure the database.
         ## url: postgres://dashboardhost:abc123@dashboardhostpostgrescluster-primary.systemlink-nic2.svc:5432/grafana


### PR DESCRIPTION
- [X] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/install-systemlink-enterprise/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

It isn't intuitive that Grafana's database must be created manually ahead of time. We've been bit by this a few times, so we should document it. While I have this file open, I'm also updating the example URL for Dremio's distributed storage configuration. I realized that dots are used to separate the FQDN segments, and not dashes.

### Why should this Pull Request be merged?

This improves the documentation in our customer-facing values file.

### What testing has been done?

We've tested this configuration internally.