### PR TITLE
Rename License Service template values

### DIFF
--- a/getting-started/templates/systemlink-secrets.yaml
+++ b/getting-started/templates/systemlink-secrets.yaml
@@ -120,7 +120,7 @@ userservices:
       - serviceName: "jupyterhub"
         key: ""
         hash: "<SHA512 hash of key>"
-      - serviceName: "licenseservicelimo"
+      - serviceName: "license"
         key: ""
         hash: "<SHA512 hash of key>"
       - serviceName: "nbexec-argo-workflow"
@@ -395,7 +395,7 @@ routineservice:
 
 ## Secret configuration for licensing
 ##
-licenseservicelimo:
+license:
   secrets:
     ## Credentials for the MongoDB cluster.
     ##

--- a/getting-started/templates/systemlink-values.yaml
+++ b/getting-started/templates/systemlink-values.yaml
@@ -691,7 +691,7 @@ nbexecservice:
 
 ## Configuration for licensing
 ##
-licenseservicelimo:
+license:
   ## Persistent Volume configuration
   ##
   persistentVolume:


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/install-systemlink-enterprise/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

We recently renamed the License Service Pods, Secrets, and other Helm value and need to update the customer facing getting started templates.  These will need to be configured by the end-user at the time of SLE installation once the License Service is added back to the Umbrella Helm chart.

### Why should this Pull Request be merged?

The PRs to rename the License Service Helm resources have already gone in.  When the PR to add the License Service back to the Umbrella Helm chart goes in, we want the customer facing templates to match the actual values.

### What testing has been done?

None for this PR.  The Helm resource rename was successfully deployed to [Main-Dev](https://ni.visualstudio.com/DevCentral/_build/results?buildId=3518588&view=results).  Main-Test had a failure due to the Terraform values not getting deployed and I'll work with Neil Stoddard to fix that come Monday.

**Note**: This PR should wait to go in until after the GM October release is finalized.  We don't want to cause churn on that process.