### PR TITLE
Add new routine-related whitelistedApiKeys

### DIFF
--- a/getting-started/templates/systemlink-secrets.yaml
+++ b/getting-started/templates/systemlink-secrets.yaml
@@ -138,6 +138,15 @@ userservices:
       - serviceName: "webserver"
         key: ""
         hash: "<SHA512 hash of key>"
+      - serviceName: "routineeventtrigger"
+        key: ""
+        hash: "<SHA512 hash of key>"
+      - serviceName: "routinescheduletrigger"
+        key: ""
+        hash: "<SHA512 hash of key>"
+      - serviceName: "routineexecutor"
+        key: ""
+        hash: "<SHA512 hash of key>"
 
 ## Secret configuration for Asset Management
 ##


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/install-systemlink-enterprise/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Adds new required values for whitelisted API Key generation.

### Why should this Pull Request be merged?

These new secrets will be used by the `routineeventtrigger`, `routinescheduletrigger` and `routineexecutor` helm charts.

A `routineservice` API Key should have been also added in previous releases but we forgot to document this. That value is no longer required now

### What testing has been done?

N/A
