### PR TITLE
Add "artifactory" segment to Grafana genericArtifactPull url

### DIFF
--- a/getting-started/templates/systemlink-secrets.yaml
+++ b/getting-started/templates/systemlink-secrets.yaml
@@ -46,7 +46,7 @@ secrets:
   genericArtifactPull:
     ## URL for the repository.
     ##
-    url: "https://niedge01.jfrog.io/ni-generic" # <ATTENTION> - Override if mirroring the SystemLink container registry.
+    url: "https://niedge01.jfrog.io/artifactory/ni-generic" # <ATTENTION> - Override if mirroring the SystemLink container registry.
     ## User for repository access. This will be the same as the image pull credentials.
     ##
     user: *imageRegistryUser


### PR DESCRIPTION
- [X] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/install-systemlink-enterprise/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

The existing URL doesn't work out of the box. Adding the "artifactory" segement fixes this issue.

### Why should this Pull Request be merged?

Fixes broken URL.

### What testing has been done?

This was validated with the September release on the customer success Rancher cluster.

More info can be found [here](https://ni.visualstudio.com/DevCentral/_workitems/edit/2205091).
