### PR TITLE
Update README with sl-jupyterhub breaking changes

### DIFF
--- a/release-notes/2022-12/README.md
+++ b/release-notes/2022-12/README.md
@@ -47,6 +47,8 @@ The 2022-12 release bundle for SystemLink Enterprise has been published to <http
 - `notification 0.1.0`
     - Newly included chart
     - You must configure a secret for MongoDB credentials in `notification.secrets.mongodb`
+- `sl-jupyterhub 0.2.0`
+    - The default configuration doesn't allow anymore user pods to establish outbound connections to private IPs (for example accessing SystemLink APIs that are exposed on a private IP from Jupyter Notebooks or the Jupyter terminal). To allow this, you must explicitly set `jupyterhub.singleuser.networkPolicy.egressAllowRules.privateIPs=true`.
 
 ## Bugs Fixed
 


### PR DESCRIPTION
- [X] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/install-systemlink-enterprise/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Specifying `sl-jupyterhub` helm chart breaking changes.

### Why should this Pull Request be merged?

Specifies helm chart breaking change.

### What testing has been done?

Tested that setting the mentioned helm chart value allows access to private IPs from Jupyter.
