### PR TITLE
Increase memory for strimzi-kafka-operator to decrease restart rate

### DIFF
--- a/getting-started/templates/systemlink-admin-values.yaml
+++ b/getting-started/templates/systemlink-admin-values.yaml
@@ -26,12 +26,14 @@ strimzi-kafka-operator:
   watchAnyNamespace: true
   podSecurityContext: 
     runAsNonRoot: true
-  ## Uncomment to set Java heap size
-  ## Only required if the operator is crashing with
-  ## "Terminating due to java.lang.OutOfMemoryError: Java heap space"
-  #extraEnvs:
-  #  - name: JAVA_OPTS
-  #    value: "-Xms256m -Xmx256m"
+  extraEnvs:
+   - name: JAVA_OPTS
+     value: "-Xms256m -Xmx256m"
+  resources:
+    requests:
+      memory: 512Mi
+    limits:
+      memory: 512Mi
 
   ## The registry where kafka images are stored.
   defaultImageRegistry: *imageRegistryRef


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/install-systemlink-enterprise/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

This PR increases the memory assigned to the strimzi-cluster-operator. Increasing the operator memory reduces the restart rate for the pod managing all Kafka related resources. 

### Why should this Pull Request be merged?

Although, this does not impact functionality, it was brought up by one of the engineers supervising the deployment on premise of one of our customers.

### What testing has been done?

I have already deployed this change in our Rancher cluster and I didn't see any restarts from the pod in 13 hrs.
