### PR TITLE
Add patch versions of helm charts to release notes.

### DIFF
--- a/release-notes/2023-01/README.md
+++ b/release-notes/2023-01/README.md
@@ -28,9 +28,9 @@ Only customer facing bugs have been included in this list.
 
 ## Versions
 
-**Top Level Helm Chart:** `systemlink 0.10.0`
+**Top Level Helm Chart:** `systemlink 0.10.92`
 
-**Admin Helm Chart:** `systemlink-admin 0.10.0`
+**Admin Helm Chart:** `systemlink-admin 0.10.4`
 
 ### NI Containers
 


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/install-systemlink-enterprise/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

I previously grabbed the versions from the helm charts themselves which do not include the patch versions, this PR adds the patch versions of the helm charts in the latest release bundle.

### What testing has been done?

Documentation change, no testing required.
