### PR TITLE
Add global telemetry configuration section

### DIFF
--- a/getting-started/templates/systemlink-values.yaml
+++ b/getting-started/templates/systemlink-values.yaml
@@ -48,6 +48,15 @@ global:
   # <ATTENTION> - Set to false if you do not want to manage secrets as part of the Helm installation.
   ##
   deploySecrets: true
+  ## Customize telemetry data collection.
+  ##
+  telemetry:
+    ## Turn telemetry data collection on or off.
+    ##
+    enabled: false
+    ## Url target of OpenTelemetry exporter. Corresponds to OTEL_EXPORTER_OTLP_ENDPOINT.
+    ##
+    openTelemetryExporterOtlpEndpoint: ""
 
 ## Core configuration for the SystemLink web application.
 ##

--- a/getting-started/templates/systemlink-values.yaml
+++ b/getting-started/templates/systemlink-values.yaml
@@ -55,6 +55,7 @@ global:
     ##
     enabled: false
     ## Url target of OpenTelemetry exporter. Corresponds to OTEL_EXPORTER_OTLP_ENDPOINT.
+    ## https://opentelemetry.io/docs/concepts/sdk-configuration/otlp-exporter-configuration/#otel_exporter_otlp_endpoint
     ##
     openTelemetryExporterOtlpEndpoint: ""
 

--- a/getting-started/templates/systemlink-values.yaml
+++ b/getting-started/templates/systemlink-values.yaml
@@ -51,7 +51,7 @@ global:
   ## Customize telemetry data collection.
   ##
   telemetry:
-    ## Turn telemetry data collection on or off.
+    ## Specify whether to collect telemetry data.
     ##
     enabled: false
     ## Url target of OpenTelemetry exporter. Corresponds to OTEL_EXPORTER_OTLP_ENDPOINT.


### PR DESCRIPTION
- [X] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/install-systemlink-enterprise/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Adds global telemetry configuration section to systemlink-values.yaml.

### Why should this Pull Request be merged?

These configurations are now required to enable metrics collection for both OpenTelemetry and Prometheus. As far as I'm aware we currently only have OpenTelmetry metrics for Test Monitor and DFS (both in active development), but this also turns on/off Prometheus scraping for Kafka and KafkaConnect now.

### What testing has been done?

Trivial values changes - tested on Stratus clusters.
