### PR TITLE
Document global.telemetry.includeUserInfo value

### DIFF
--- a/getting-started/templates/systemlink-values.yaml
+++ b/getting-started/templates/systemlink-values.yaml
@@ -59,6 +59,8 @@ global:
     ##
     openTelemetryExporterOtlpEndpoint: ""
     ## Specify whether to include user IDs in traces.
+    ## Turned off by default per recommendation of the OpenTelemetry Specification.
+    ## https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/span-general.md#general-identity-attributes
     ##
     includeUserInfo: false
 

--- a/getting-started/templates/systemlink-values.yaml
+++ b/getting-started/templates/systemlink-values.yaml
@@ -58,6 +58,9 @@ global:
     ## https://opentelemetry.io/docs/concepts/sdk-configuration/otlp-exporter-configuration/#otel_exporter_otlp_endpoint
     ##
     openTelemetryExporterOtlpEndpoint: ""
+    ## Specify whether to include user IDs in traces.
+    ##
+    includeUserInfo: false
 
 ## Core configuration for the SystemLink web application.
 ##


### PR DESCRIPTION
- [X] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/install-systemlink-enterprise/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Documents the `global.telemetry.includeUserInfo` Helm value.

### Why should this Pull Request be merged?

This configuration is useful for non-repudiation, but is a potential security concern so is put behind a toggle that defaults to false.

### What testing has been done?

Documentation change.
