### PR TITLE
Add instructions for recovery after unexpected RabbitMQ shutdown

### DIFF
--- a/getting-started/templates/systemlink-values.yaml
+++ b/getting-started/templates/systemlink-values.yaml
@@ -76,7 +76,7 @@ rabbitmq:
   podManagementPolicy: "OrderedReady"
   # podManagementPolicy: "Parallel"
   clustering:
-    ## Force boot of an unexpectedly shut down cluster (in an unexpected order).
+    ## Force boot of a cluster after an unexpected shutdown (in an unexpected order).
     ##
     forceBoot: false
 

--- a/getting-started/templates/systemlink-values.yaml
+++ b/getting-started/templates/systemlink-values.yaml
@@ -71,7 +71,7 @@ rabbitmq:
   # <ATTENTION> - RabbitMQ pods must be started in reverse order of how they were shut down.
   #               After an unexpected shutdown of the cluster, temporarily set podManagementPolicy
   #               to "Parallel" and forceBoot to true to restore the cluster to a healthy state.
-  #               https://artifacthub.io/packages/helm/bitnami/rabbitmq#recover-the-cluster-from-complete-shutdown
+  #               https://github.com/bitnami/charts/tree/main/bitnami/rabbitmq#recover-the-cluster-from-complete-shutdown
   ##
   podManagementPolicy: "OrderedReady"
   # podManagementPolicy: "Parallel"

--- a/getting-started/templates/systemlink-values.yaml
+++ b/getting-started/templates/systemlink-values.yaml
@@ -69,8 +69,8 @@ global:
 rabbitmq:
   ## Policy used when starting pods in the stateful set.
   # <ATTENTION> - RabbitMQ pods must start in reverse shutdown order.
-  #               After an unexpected shutdown of the cluster, temporarily set podManagementPolicy
-  #               to "Parallel" and forceBoot to true to restore the cluster to a healthy state.
+  #               To restore the cluster to a healthy state after an unexpected shutdown, temporarily set
+  #               podManagementPolicy to "Parallel" and forceBoot to true.
   #               https://github.com/bitnami/charts/tree/main/bitnami/rabbitmq#recover-the-cluster-from-complete-shutdown
   ##
   podManagementPolicy: "OrderedReady"

--- a/getting-started/templates/systemlink-values.yaml
+++ b/getting-started/templates/systemlink-values.yaml
@@ -76,7 +76,7 @@ rabbitmq:
   podManagementPolicy: "OrderedReady"
   # podManagementPolicy: "Parallel"
   clustering:
-    ## Force boot of a cluster after an unexpected shutdown (in an unexpected order).
+    ## Force cluster to boot after an unexpected shutdown (in an unexpected order).
     ##
     forceBoot: false
 

--- a/getting-started/templates/systemlink-values.yaml
+++ b/getting-started/templates/systemlink-values.yaml
@@ -64,6 +64,22 @@ global:
     ##
     includeUserInfo: false
 
+## Core configuration for the RabbitMQ message broker
+##
+rabbitmq:
+  ## Policy used whend starting pods in the stateful set.
+  # <ATTENTION> - RabbitMQ pods must be started in reverse order of how they were shut down.
+  #               After an unexpected shutdown of the cluster, temporarily set podManagementPolicy
+  #               to "Parallel" and forceBoot to true to restore the cluster to a healthy state.
+  #               https://artifacthub.io/packages/helm/bitnami/rabbitmq#recover-the-cluster-from-complete-shutdown
+  ##
+  podManagementPolicy: "OrderedReady"
+  # podManagementPolicy: "Parallel"
+  clustering:
+    ## Force boot of an unexpectedly shut down cluster (in an unexpected order).
+    ##
+    forceBoot: false
+
 ## Core configuration for the SystemLink web application.
 ##
 webserver:

--- a/getting-started/templates/systemlink-values.yaml
+++ b/getting-started/templates/systemlink-values.yaml
@@ -67,7 +67,7 @@ global:
 ## Core configuration for the RabbitMQ message broker
 ##
 rabbitmq:
-  ## Policy used whend starting pods in the stateful set.
+  ## Policy used when starting pods in the stateful set.
   # <ATTENTION> - RabbitMQ pods must be started in reverse order of how they were shut down.
   #               After an unexpected shutdown of the cluster, temporarily set podManagementPolicy
   #               to "Parallel" and forceBoot to true to restore the cluster to a healthy state.

--- a/getting-started/templates/systemlink-values.yaml
+++ b/getting-started/templates/systemlink-values.yaml
@@ -68,7 +68,7 @@ global:
 ##
 rabbitmq:
   ## Policy used when starting pods in the stateful set.
-  # <ATTENTION> - RabbitMQ pods must be started in reverse order of how they were shut down.
+  # <ATTENTION> - RabbitMQ pods must start in reverse shutdown order.
   #               After an unexpected shutdown of the cluster, temporarily set podManagementPolicy
   #               to "Parallel" and forceBoot to true to restore the cluster to a healthy state.
   #               https://github.com/bitnami/charts/tree/main/bitnami/rabbitmq#recover-the-cluster-from-complete-shutdown


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/install-systemlink-enterprise/blob/master/CONTRIBUTING.md).
- [ ] 
### What does this Pull Request accomplish?

RabbitMQ clusters in k8s have a known issue where the cluster can fail to restart after an unexpected shutdown. We are seeing this at customer sites. Adding documentation to our template on the recommended workaround for this issue.

### Why should this Pull Request be merged?

Will help customers who encounter this issue in the future.

### What testing has been done?

N/A
