### PR TITLE
Clarify encoding requirements for encryption keys

### DIFF
--- a/getting-started/templates/systemlink-secrets.yaml
+++ b/getting-started/templates/systemlink-secrets.yaml
@@ -243,7 +243,7 @@ dataframeservice:
 ##
 fileingestion:
   secrets:
-    ## Cryptographic key to be used for AES-256 encryption of data at rest. This key should have a length of 32 bytes. The key value must be Base64 encoded.
+    ## Cryptographic key used for AES-256 encryption of data at restI. Use a 32-byte cryptographically random value which is base64 encoded.
     ##
     encryptionKey: ""  # <ATTENTION>
     ## Access key information for S3/MinIO access.
@@ -406,7 +406,7 @@ webappservices:
       ## Refer to the MongoDB documentation for key generation: https://www.mongodb.com/docs/manual/tutorial/enforce-keyfile-access-control-in-existing-replica-set/#create-a-keyfile
       ##
       replicaSetKey: ""  # <ATTENTION>
-    ## Key used to encrypt continuation tokens produced by the API. This is an AEAD key with a length of 32 bytes. The key value must be Base64 encoded.
+    ## Cryptographic key used for AEAD encryption of continuation tokens. Use a 32-byte cryptographically random value which is base64 encoded.
     ##
     continuationTokenEncryptionKey: ""  # <ATTENTION>
 


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/install-systemlink-enterprise/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Keys used by Elixir services expect the value stored in the Helm chart will be base64 encoded. Making sure this is explicitly documented. 

### Why should this Pull Request be merged?

We had internal deployments that had failed to format keys correctly because this requirement was not clear in the documentation. Trying to prevent that happening to users.

### What testing has been done?

N/A
