### PR TITLE
Remove kafka-ui image registry override value

### DIFF
--- a/getting-started/templates/systemlink-values.yaml
+++ b/getting-started/templates/systemlink-values.yaml
@@ -609,8 +609,6 @@ dataframeservice:
   ## Configure Kafka UI
   ##
   kafka-ui:
-    image:
-      registry: *imageRegistryRef
     imagePullSecrets:
       - name: *niPullSecret
 


### PR DESCRIPTION
- [X] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/install-systemlink-enterprise/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Remove the kafka-ui image registry override configuration.

### Why should this Pull Request be merged?

These values are no longer needed as the new version of the kafka-ui chart supports global image registry.

### What testing has been done?

Trivial values file updates.
