### PR TITLE
Add new sl-jupyterhub default helm values

### DIFF
--- a/getting-started/templates/systemlink-values.yaml
+++ b/getting-started/templates/systemlink-values.yaml
@@ -678,13 +678,6 @@ sl-jupyterhub:
         ## Setting this to "true" will enable the legacy implementation of Jupyter usernames.
         JUPYTER_USERNAME_AS_SYSTEMLINK_USER_ID: "false"
     singleuser:
-      cpu:
-        # <ATTENTION> - Use numeric values like .5, 1, 1.5, as Jupyter has this convention for CPU resource allocation.
-        guarantee: .5
-      memory:
-        # <ATTENTION> - Use G as unit, instead of Gi, as Jupyter has this convention for memory resource allocation.
-        limit: 2G
-        guarantee: 2G
       networkPolicy:
         egressAllowRules:
           # <ATTENTION> - Set to true to enable JupyterHub user pods to establish outbound connections to private IP addresses.

--- a/getting-started/templates/systemlink-values.yaml
+++ b/getting-started/templates/systemlink-values.yaml
@@ -675,7 +675,7 @@ sl-jupyterhub:
     imagePullSecrets: *pullSecrets
     hub:
       extraEnv:
-        ## Setting this to "true" will enable the legacy implementation of Jupyter usernames, which is based on user IDs.
+        ## Setting this to "true" will enable the legacy implementation of Jupyter usernames.
         JUPYTER_USERNAME_AS_SYSTEMLINK_USER_ID: "false"
     singleuser:
       cpu:

--- a/getting-started/templates/systemlink-values.yaml
+++ b/getting-started/templates/systemlink-values.yaml
@@ -675,13 +675,14 @@ sl-jupyterhub:
     imagePullSecrets: *pullSecrets
     hub:
       extraEnv:
+        ## Setting this to "true" will enable the legacy implementation of Jupyter usernames, which is based on user IDs.
         JUPYTER_USERNAME_AS_SYSTEMLINK_USER_ID: "false"
     singleuser:
       cpu:
-        # <ATTENTION> - Use numeric values like .5, 1, 1.5, as Jupyter has this convention for CPU resource allocation
+        # <ATTENTION> - Use numeric values like .5, 1, 1.5, as Jupyter has this convention for CPU resource allocation.
         guarantee: .5
       memory:
-        # <ATTENTION> - Use G as unit, instead of Gi, as Jupyter has this convention for memory resource allocation
+        # <ATTENTION> - Use G as unit, instead of Gi, as Jupyter has this convention for memory resource allocation.
         limit: 2G
         guarantee: 2G
       networkPolicy:

--- a/getting-started/templates/systemlink-values.yaml
+++ b/getting-started/templates/systemlink-values.yaml
@@ -673,7 +673,17 @@ fileingestion:
 sl-jupyterhub:
   jupyterhub:
     imagePullSecrets: *pullSecrets
+    hub:
+      extraEnv:
+        JUPYTER_USERNAME_AS_SYSTEMLINK_USER_ID: "false"
     singleuser:
+      cpu:
+        # <ATTENTION> - Use numeric values like .5, 1, 1.5, as Jupyter has this convention for CPU resource allocation
+        guarantee: .5
+      memory:
+        # <ATTENTION> - Use G as unit, instead of Gi, as Jupyter has this convention for memory resource allocation
+        limit: 2G
+        guarantee: 2G
       networkPolicy:
         egressAllowRules:
           # <ATTENTION> - Set to true to enable JupyterHub user pods to establish outbound connections to private IP addresses.


### PR DESCRIPTION
- [ ] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/install-systemlink-enterprise/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

The `sl-jupyterhub` 1.0.0 helm chart brings a breaking change, as Jupyter usernames will be based on user emails instead of user emails. Clients can opt-out of this by setting the JUPYTER_USERNAME_AS_SYSTEMLINK_USER_ID helm value to "true", to use the legacy implementation.

Also, the resource allocation for user pods changed. Specifying the defaults here such that, if clients wish to have more or less, they can easily find where to change it.

### Why should this Pull Request be merged?

The helm values are displayed in the template for easier modification.

### What testing has been done?

This values have been tested on our dev and test environments.
