### PR TITLE
Update fileingestion values to reflect large files upload

### DIFF
--- a/getting-started/templates/systemlink-values.yaml
+++ b/getting-started/templates/systemlink-values.yaml
@@ -644,6 +644,8 @@ fileingestion:
     ##
     annotations:
       nginx.ingress.kubernetes.io/proxy-body-size: 2000m
+      nginx.ingress.kubernetes.io/proxy-request-buffering: "off"
+      nginx.ingress.kubernetes.io/proxy-buffering: "off"
 
   ## Configure S3/MinIO access.
   ##
@@ -679,6 +681,8 @@ fileingestion:
     ## Upload file
     ##
     upload: 3
+  # Configure the maximum accepted size of uploaded files, expressed in gigabytes.
+  uploadLimitGB: 10
 
 ## Configuration for JupyterHub.
 ##


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/install-systemlink-enterprise/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

1. Add the ingress options that we use on rancher, to reflect that in order to upload large files, you need to turn off the proxy request buffering
2. Document the `uploadLimitGB` field

### Why should this Pull Request be merged?

Better documentation for file uploads for clients

### What testing has been done?

N/A
