### PR TITLE
Added example for configuring Dataframe service rate limits

### DIFF
--- a/getting-started/templates/systemlink-values.yaml
+++ b/getting-started/templates/systemlink-values.yaml
@@ -512,20 +512,21 @@ dataframeservice:
   ##
   requestBodySizeLimitMegabytes: 250
 
-  ## Configure rate limiting. Limits are enforced per-replica. Each replica of the dataframe service
-  ## applies its own limit. With load-balancing, the effective rate will be higher than the
+  ## <ATTENTION> - Configure rate limiting. Limits are enforced per-replica. 
+  ## Each replica of the dataframe service applies its own limit. 
+  ## Considering load-balancing, the effective rate will be higher than the
   ## individual rates configured here.
   ##
   rateLimits:
     ## Configure rate limits for ingestion
     ##
     ingestion:
-      ## Number of concurrent requests that a single pod can serve for ingesting data.
+      ## Number of concurrent requests that a single replica can serve for ingesting data.
       ## Subsequent requests will be put in a queue.
       ##
       requestsLimit: 20
       ## Size of the queue for concurrent requests. If a request arrives to a pod with a full queue,
-      ## the pod will return a 429 Error code.
+      ## the replica will return a 429 Error code.
       queueSize: 0
 
   ## Configure S3/MinIO access.

--- a/getting-started/templates/systemlink-values.yaml
+++ b/getting-started/templates/systemlink-values.yaml
@@ -512,6 +512,22 @@ dataframeservice:
   ##
   requestBodySizeLimitMegabytes: 250
 
+  ## Configure rate limiting. Limits are enforced per-replica. Each replica of the dataframe service
+  ## applies its own limit. With load-balancing, the effective rate will be higher than the
+  ## individual rates configured here.
+  ##
+  rateLimits:
+    ## Configure rate limits for ingestion
+    ##
+    ingestion:
+      ## Number of concurrent requests that a single pod can serve for ingesting data.
+      ## Subsequent requests will be put in a queue.
+      ##
+      requestsLimit: 20
+      ## Size of the queue for concurrent requests. If a request arrives to a pod with a full queue,
+      ## the pod will return a 429 Error code.
+      queueSize: 0
+
   ## Configure S3/MinIO access.
   ##
   s3:


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/install-systemlink-enterprise/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Includes and example for configuring rate limits for Dataframe service with the default values.

### Why should this Pull Request be merged?

This gives an example to costumers on how to configure the concurrent requests handled by each of the replicas of the Dataframe service.

### What testing has been done?

Testing with helm template
