### PR TITLE
Added appendableTableLimit configuration for Dataframe service

### DIFF
--- a/getting-started/templates/systemlink-values.yaml
+++ b/getting-started/templates/systemlink-values.yaml
@@ -509,6 +509,15 @@ dataframeservice:
     annotations:
       nginx.ingress.kubernetes.io/proxy-body-size: 256m
 
+  ## <ATTENTION> - Configure ingestion appendable table limit.
+  ##
+  ingestion:
+    ## The number of distinct tables that can be appended to before table creation will be blocked.
+    ## To stay under this limit, set 'endOfData: true' on tables that don't need to be appended to anymore.
+    ## For more information, visit ni.com/r/setendofdata.
+    ##
+    appendableTableLimit: 250
+
   ## Limits the body size for requests in megabytes. The ingress may also impose a request body size
   ## limit, which should be set to the same value.
   ##


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/install-systemlink-enterprise/blob/master/CONTRIBUTING.md).


### What does this Pull Request accomplish?

Includes the default value for appendable table limit and description to help the user tune their deployment.

### Why should this Pull Request be merged?

This is a configuration option added for the 2023-04 release of the Dataframe service. This PR describes the new configuration and points to a [knowledge base article about it](ni.com/r/setendofdata)


### What testing has been done?

`helm template`
