### PR TITLE
Add dashboardhost apiIngress for Grafana

### DIFF
--- a/getting-started/templates/systemlink-values.yaml
+++ b/getting-started/templates/systemlink-values.yaml
@@ -315,11 +315,6 @@ dashboardhost:
     ## Enable the ingress.
     ##
     enabled: true
-    ## For Kubernetes >= 1.18 you should specify the ingress-controller via the field ingressClassName
-    ## See https://kubernetes.io/blog/2020/04/02/improvements-to-the-ingress-api-in-kubernetes-1.18/#specifying-the-class-of-an-ingress
-    # <ATTENTION> - Configure you ingress controller class name.
-    ##
-    ingressClassName: "nginx"
     ## Values can be templated.
     ##
     annotations: {}
@@ -340,11 +335,6 @@ dashboardhost:
     ## Enable the ingress.
     ##
     enabled: true
-    ## For Kubernetes >= 1.18 you should specify the ingress-controller via the field ingressClassName
-    ## See https://kubernetes.io/blog/2020/04/02/improvements-to-the-ingress-api-in-kubernetes-1.18/#specifying-the-class-of-an-ingress
-    # <ATTENTION> - Configure you ingress controller class name.
-    ##
-    ingressClassName: "nginx"
     ## Values can be templated.
     ##
     annotations: {}

--- a/getting-started/templates/systemlink-values.yaml
+++ b/getting-started/templates/systemlink-values.yaml
@@ -334,6 +334,31 @@ dashboardhost:
     extraPaths: []
     tls: []
 
+  ## This API ingress makes it possible to expose elements of the Grafana backend API via the API ingress.
+  ##
+  apiIngress:
+    ## Enable the ingress.
+    ##
+    enabled: true
+    ## For Kubernetes >= 1.18 you should specify the ingress-controller via the field ingressClassName
+    ## See https://kubernetes.io/blog/2020/04/02/improvements-to-the-ingress-api-in-kubernetes-1.18/#specifying-the-class-of-an-ingress
+    # <ATTENTION> - Configure you ingress controller class name.
+    ##
+    ingressClassName: "nginx"
+    ## Values can be templated.
+    ##
+    annotations: {}
+    labels: {}
+    path: "/dashboardhost"
+    ## pathType is only for k8s >= 1.1=.
+    ##
+    pathType: "Prefix"
+    hosts: *apiHosts
+    ## Extra paths to prepend to every host configuration. This is useful when working with annotation based services.
+    ##
+    extraPaths: []
+    tls: []
+
   ## Grafana community chart configuration. See https://github.com/grafana/helm-charts/blob/main/charts/grafana/README.md
   ## for more documentation and examples for these values.
   ##

--- a/getting-started/templates/systemlink-values.yaml
+++ b/getting-started/templates/systemlink-values.yaml
@@ -312,42 +312,18 @@ dashboardhost:
   ## The Grafana ingress is disabled by default so no further configuration is required under the "grafana" section.
   ##
   ingress:
-    ## Enable the ingress.
-    ##
-    enabled: true
     ## Values can be templated.
     ##
     annotations: {}
-    labels: {}
-    path: "/dashboardhost"
-    ## pathType is only for k8s >= 1.1=.
-    ##
-    pathType: "Prefix"
     hosts: *uiHosts
-    ## Extra paths to prepend to every host configuration. This is useful when working with annotation based services.
-    ##
-    extraPaths: []
-    tls: []
 
   ## This API ingress makes it possible to expose elements of the Grafana backend API via the API ingress.
   ##
   apiIngress:
-    ## Enable the ingress.
-    ##
-    enabled: true
     ## Values can be templated.
     ##
     annotations: {}
-    labels: {}
-    path: "/dashboardhost"
-    ## pathType is only for k8s >= 1.1=.
-    ##
-    pathType: "Prefix"
     hosts: *apiHosts
-    ## Extra paths to prepend to every host configuration. This is useful when working with annotation based services.
-    ##
-    extraPaths: []
-    tls: []
 
   ## Grafana community chart configuration. See https://github.com/grafana/helm-charts/blob/main/charts/grafana/README.md
   ## for more documentation and examples for these values.


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/install-systemlink-enterprise/blob/master/CONTRIBUTING.md).

Updated 2023-06 breaking changes for release notes [here](https://nio365.sharepoint.com/:x:/r/sites/ASWSystemLink/Shared%20Documents/SLE%20Development/Helm%20Chart%20Breaking%20Changes,%20Software%20Behavior%20Changes%20for%20the%20Release%20Notes%20-%20out%20of%20May%202023%20(SLE%202023-06).xlsx?d=w8144df90bcf644ef8aacda6e44615d76&csf=1&web=1&e=HWacZM).

### What does this Pull Request accomplish?

Add the new apiIngress section to the dashboardhost values.
Also cleaned up and removed properties that we don't expect the user to change here from the main ingress.

### Why should this Pull Request be merged?

We need to expose Grafana's API on the API Ingress in order to address [Bug 2373035](https://dev.azure.com/ni/DevCentral/_workitems/edit/2373035): [Prod] The dashboard app appears in the navigation tree on prod

### What testing has been done?

`helm template`
