### PR TITLE
Update release-notes-template.md

### DIFF
--- a/chapter-template/release-notes-template.md
+++ b/chapter-template/release-notes-template.md
@@ -2,7 +2,7 @@
 
 # SystemLink Enterprise release year-release-month Release Notes
 
-The release_year-release_month release bundle for SystemLink Enterprise has been published to <https://niedge01.jfrog.io>. This update includes new features, bug fixes, and security updates. Work with your account representative to obtain credentials to access these artifacts. If you are not upgrading from the previous release, refer to past release notes to ensure you have addressed all required configuration changes.
+The release_year-release_month release bundle for SystemLink Enterprise has been published to <https://downloads.artifacts.ni.com>. This update includes new features, bug fixes, and security updates. Work with your account representative to obtain credentials to access these artifacts. If you are not upgrading from the previous release, refer to past release notes to ensure you have addressed all required configuration changes.
 
 ## Upgrading from the release year-release-month to the release year-release-month
 
@@ -43,12 +43,12 @@ Only customer facing bugs have been included in this list.
 
 ### NI Containers
 
-container/version
+container:version
 
 ### Non Container/Chart Artifacts
 
-artifact/version
+artifact:version
 
 ### 3rd Party Containers
 
-container/version
+container:version


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/install-systemlink-enterprise/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Updates release notes template to use the NI domain for the artifactory DNS rather than the ones that have jfrog in the hostname. 

Changes to use `:` rather than `/` between artifact name and tag. This aligns better with how the artifact lists we product in builds and how docker specified tags. 

### Why should this Pull Request be merged?

Improved the release notes template. 

### What testing has been done?

NA
