### PR TITLE
Remove unnecessary autoscaler config for Grafana

### DIFF
--- a/getting-started/templates/systemlink-values.yaml
+++ b/getting-started/templates/systemlink-values.yaml
@@ -346,17 +346,6 @@ dashboardhost:
     autoscaling:
       # <ATTENTION> - If not using an external database, you must disable autoscaling and use a single Grafana instance.
       enabled: true
-      minReplicas: 2
-      maxReplicas: 10
-      metrics:
-      - type: "Resource"
-        resource:
-          name: "cpu"
-          targetAverageUtilization: 60
-      - type: "Resource"
-        resource:
-          name: "memory"
-          targetAverageUtilization: 70
 
     ## Use an existing secret for the admin user.
     # <ATTENTION> - Uncomment this section to use a different secret to configure the admin user.


### PR DESCRIPTION
- [X] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/install-systemlink-enterprise/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

In a [PR comment](https://dev.azure.com/ni/DevCentral/_git/Skyline/pullRequest/523128#1689686266), we determined that we were unnecessarily duplicating some of Grafana's autoscaler config in this file.

I left the bit about enabling or disabling the autoscaler based on whether or not the user is connecting Grafana to an external database, as I think that's important enough to surface here.

### Why should this Pull Request be merged?

Removes unnecessary configuration, keeping the `systemlink-values.yaml` file smaller.

### What testing has been done?

I verified that the values that we're removing are identical to the defaults specified in the Grafana chart [here](https://dev.azure.com/ni/DevCentral/_git/Skyline?path=/Grafana/helm/values.yaml&version=GBusers/pvallone/audit-checklist-tracing&line=203&lineEnd=216&lineStartColumn=1&lineEndColumn=37&lineStyle=plain&_a=contents).