### PR TITLE
Add taghistorian secrets

### DIFF
--- a/getting-started/templates/systemlink-secrets.yaml
+++ b/getting-started/templates/systemlink-secrets.yaml
@@ -523,9 +523,27 @@ tags:
       ## Refer to the MongoDB documentation for key generation: https://www.mongodb.com/docs/manual/tutorial/enforce-keyfile-access-control-in-existing-replica-set/#create-a-keyfile
       ##
       replicaSetKey: ""  # <ATTENTION>
+
+## Secret configuration for taghistorian
+##
+taghistorian:
+  secrets:
+    ## Credentials for the MongoDB cluster.
+    ##
+    mongodb:
+      ## Root user password for the database cluster.
+      ##
+      rootPassword: ""  # <ATTENTION>
+      ## Limited user password to allow the service to access the database. This password cannot contain commas or any character that must be escaped in a URL.
+      ##
+      servicePassword: ""  # <ATTENTION>
+      ## Key used to authenticate pods in the database cluster.
+      ## Refer to the MongoDB documentation for key generation: https://www.mongodb.com/docs/manual/tutorial/enforce-keyfile-access-control-in-existing-replica-set/#create-a-keyfile
+      ##
+      replicaSetKey: ""  # <ATTENTION>
     ## Cryptographic key used for AEAD encryption of continuation tokens. Use a 32-byte cryptographically random value which is base64 encoded.
     ##
-    continuationTokenEncryptionKey: "" # <ATTENTION>
+    continuationTokenEncryptionKey: ""  # <ATTENTION>
 
 ## Secret configuration for repository
 ##

--- a/getting-started/templates/systemlink-secrets.yaml
+++ b/getting-started/templates/systemlink-secrets.yaml
@@ -523,6 +523,9 @@ tags:
       ## Refer to the MongoDB documentation for key generation: https://www.mongodb.com/docs/manual/tutorial/enforce-keyfile-access-control-in-existing-replica-set/#create-a-keyfile
       ##
       replicaSetKey: ""  # <ATTENTION>
+    ## Cryptographic key used for AEAD encryption of continuation tokens. Use a 32-byte cryptographically random value which is base64 encoded.
+    ##
+    continuationTokenEncryptionKey: "" # <ATTENTION>
 
 ## Secret configuration for repository
 ##


### PR DESCRIPTION
- [ ] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/install-systemlink-enterprise/blob/master/CONTRIBUTING.md).

Document `TagHistorian` required secrets as it will be deployed soon.

### What does this Pull Request accomplish?

Add `taghistorian` and its secrets to the `getting started` template.

### Why should this Pull Request be merged?

Document `TagHisotrian` required secrets.

### What testing has been done?

