### PR TITLE
Document OpenTelemetry and Prometheus telemetry requirement

### DIFF
--- a/getting-started/templates/systemlink-values.yaml
+++ b/getting-started/templates/systemlink-values.yaml
@@ -55,6 +55,9 @@ global:
   ##
   telemetry:
     ## Specify whether to collect telemetry data.
+    ## Requires deployment of an OpenTelemetry collector and Prometheus.
+    ## OpenTelemetry: https://opentelemetry.io/docs/what-is-opentelemetry/
+    ## Prometheus: https://prometheus.io/docs/introduction/overview/
     ##
     enabled: false
     ## Url target of OpenTelemetry exporter. Corresponds to OTEL_EXPORTER_OTLP_ENDPOINT.


### PR DESCRIPTION
- [X] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/install-systemlink-enterprise/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Adds a note in the telemetry values configuration section that an OpenTelemetry collector and Prometheus instance must be deployed to take advantage of SLE telemetry capabilities.

### Why should this Pull Request be merged?

Improves customer documentation as it relates to observability.

### What testing has been done?

Documentation update.
