### PR TITLE
Add global.mongodb section

### DIFF
--- a/getting-started/templates/systemlink-secrets.yaml
+++ b/getting-started/templates/systemlink-secrets.yaml
@@ -4,6 +4,26 @@
 ## This is a YAML-formatted file.
 ## Declare override values for variables.
 
+global:
+  secrets:
+    mongodb:
+      ## <ATTENTION> - If `global.mongodb.install` is false, configure the external MongoDB connection string to be used by services in this deployment.
+      #
+      # If you are setting credentials per service (e.g. assetservice.secrets.mongodb.servicePassword) leave the placeholders
+      # <username> and <password> in the connection string. These will be replaced dynamically when deploying.
+      #
+      # If you have provisioned MongoDB to use a single set of credentials replace <username>:<password> with the values desired.
+      #
+      # <database> is required and will be replaced dynamically.
+      #
+      # examples:
+      # - MongoDB Atlas: mongodb+srv://<username>:<password>@my-atlas-cluster.mongodb.net/<database>
+      # - MongoDB Community: mongodb://<username>:<password>@my-mongodb-cluster-0,my-mongodb-cluster-1,my-mongodb-cluster-2/<database>?replicaSet=rs0
+      # - MongoDB Community (single set of credentials): mongodb://myusername:myPassw0rD@my-mongodb-cluster-0,my-mongodb-cluster-1,my-mongodb-cluster-2/<database>?replicaSet=rs0
+      #
+      # If `global.mongodb.install` is `true` leave the connection string as a blank string or comment it out.
+      connection_string: ""
+
 ## Secrets that apply to the entire application.
 ##
 secrets:

--- a/getting-started/templates/systemlink-values.yaml
+++ b/getting-started/templates/systemlink-values.yaml
@@ -86,30 +86,14 @@ global:
     cdnEndpoint: "https://web-sdk.ni.com/"
   ##
   ## MongoDB Database Configuration.
-  ## Many Systemlink Enterprise services utilize MongoDB databases for data storage. Customers can deploy their own MongoDB instance
-  ## or utilize a managed solution such as MongoDB Atlas. Once provisioned provide the connection details in the values below.
+  ## Many Systemlink Enterprise services utilize MongoDB databases for data storage. Customers can deploy their own MongoDB instance 
+  ## or utilize a managed solution such as MongoDB Atlas. Once provisioned provide the connection details in global.secrets.mongodb.connection_string.
   ##
   mongodb:
     ## Enable or disable installation of per-service MongoDB instances. 
     #  <ATTENTION> - If you do *not* have your own MongoDB instance set this (`global.mongodb.install`) to `true`.
     ##
     install: false 
-    ## <ATTENTION> - If `global.mongodb.install` is false, configure the external MongoDB connection string to be used by services in this deployment.
-    #
-    # If you are setting credentials per service (e.g. assetservice.secrets.mongodb.servicePassword) leave the placeholders
-    # <username> and <password> in the connection string. These will be replaced dynamically when deploying.
-    #
-    # If you have provisioned MongoDB to use a single set of credentials replace <username>:<password> with the values desired.
-    #
-    # <database> is required and will be replaced dynamically.
-    #
-    # examples:
-    # - MongoDB Atlas: mongodb+srv://<username>:<password>@my-atlas-cluster.mongodb.net/<database>
-    # - MongoDB Community: mongodb://<username>:<password>@my-mongodb-cluster-0,my-mongodb-cluster-1,my-mongodb-cluster-2/<database>?replicaSet=rs0
-    # - MongoDB Community (single set of credentials): mongodb://myusername:myPassw0rD@my-mongodb-cluster-0,my-mongodb-cluster-1,my-mongodb-cluster-2/<database>?replicaSet=rs0
-    #
-    # If `global.mongodb.install` is `true` leave the connection string as a blank string or comment it out.
-    connection_string: ""
 
 ## Core configuration for the RabbitMQ message broker
 ##

--- a/getting-started/templates/systemlink-values.yaml
+++ b/getting-started/templates/systemlink-values.yaml
@@ -84,6 +84,32 @@ global:
     ## CDN endpoint for telemetry-driven content. NI does not recommend changing this value.
     ##
     cdnEndpoint: "https://web-sdk.ni.com/"
+  ##
+  ## MongoDB Database Configuration.
+  ## Systemlink Enterprise' various services utilize MongoDB databases for data storage. Customers can deploy their own MongoDB instance
+  ## or utilize a managed solution such as MongoDB Atlas. Once provisioned provide the connection details in the values below.
+  ##
+  mongodb:
+    ## Enable or disable installation of per-service MongoDB instances. 
+    #  <ATTENTION> - If you do *not* have your own MongoDB instance set this (`global.mongodb.install`) to `true`.
+    ##
+    install: false 
+    ## <ATTENTION> - If `global.mongodb.install` is false, configure the external MongoDB connection string to be used by services in this deployment.
+    #
+    # If you are setting credentials per service (e.g. assetservice.secrets.mongodb.servicePassword) leave the placeholders
+    # <username> and <password> in the connection string. These will be replaced dynamically when deploying.
+    #
+    # If you have provisioned MongoDB to use a single set of credentials replace <username>:<password> with the values desired.
+    #
+    # <database> is required and will be replaced dynamically.
+    #
+    # examples:
+    # - MongoDB Atlas: mongodb+srv://<username>:<password>@my-atlas-cluster.mongodb.net/<database>
+    # - MongoDB Community: mongodb://<username>:<password>@my-mongodb-cluster-0,my-mongodb-cluster-1,my-mongodb-cluster-2/<database>?replicaSet=rs0
+    # - MongoDB Community (single set of credentials): mongodb://myusername:myPassw0rD@my-mongodb-cluster-0,my-mongodb-cluster-1,my-mongodb-cluster-2/<database>?replicaSet=rs0
+    #
+    # If `global.mongodb.install` is `true` leave the connection string as a blank string or comment it out.
+    connection_string: ""
 
 ## Core configuration for the RabbitMQ message broker
 ##

--- a/getting-started/templates/systemlink-values.yaml
+++ b/getting-started/templates/systemlink-values.yaml
@@ -86,7 +86,7 @@ global:
     cdnEndpoint: "https://web-sdk.ni.com/"
   ##
   ## MongoDB Database Configuration.
-  ## Systemlink Enterprise' various services utilize MongoDB databases for data storage. Customers can deploy their own MongoDB instance
+  ## Many Systemlink Enterprise services utilize MongoDB databases for data storage. Customers can deploy their own MongoDB instance
   ## or utilize a managed solution such as MongoDB Atlas. Once provisioned provide the connection details in the values below.
   ##
   mongodb:


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/install-systemlink-enterprise/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Adds the `global.mongodb` section to the getting started templates values file

### Why should this Pull Request be merged?

The default for MongoDB connection to and external instance is changing in the October release. We need to update documentation/getting started-type guides.

### What testing has been done?

Stratus main-dev is running on MongoDB Atlas.
