### PR TITLE
Add values to getting started template for postgres migration user.

### DIFF
--- a/getting-started/templates/systemlink-secrets.yaml
+++ b/getting-started/templates/systemlink-secrets.yaml
@@ -438,26 +438,6 @@ testmonitorservice:
       ##
       migrationConnectionPassword: ""
 
-  database:
-    ## @param secrets.database.connectionString Connection string the service will use when connecting to the PostgresSQL database.
-    ## NOTE: Ignored unless `database.connectionString.secretName` parameter is set.
-    ##
-    connectionString: ""
-    ## @param secrets.database.migrationConnectionString Connection string that is used to perform PostgreSQL schema migrations managed by this chart.
-    ## NOTE: Ignored unless `database.connectionString.secretName` and `database.connectionString.migrationConnectionStringKey` parameters are set.
-    ##
-    migrationConnectionString: ""
-    ## @param secrets.database.connectionPassword Password for the PostgresSQL user the service will use to connect to PostgreSQL.
-    ## Pairs with the username set with `database.connectionInfo.user`.
-    ## NOTE: Ignored if `database.connectionString.secretName` parameter is set.
-    ##
-    connectionPassword: ""
-    ## @param secrets.database.migrationConnectionPassword Password for the PostgresSQL user that will perform database migrations managed by this chart.
-    ## Pairs with the username set with `database.connectionInfo.migrationUser`.
-    ## NOTE: Ignored if `database.connectionString.secretName` parameter is set or `database.connectionInfo.migrationPasswordKey` is unset.
-    ##
-    migrationConnectionPassword: ""
-
 ## Secret configuration for user data
 ##
 userdata:

--- a/getting-started/templates/systemlink-secrets.yaml
+++ b/getting-started/templates/systemlink-secrets.yaml
@@ -428,6 +428,35 @@ testmonitorservice:
       ## NOTE: Ignored if `database.secretName` parameter is set.
       ##
       connectionPassword: ""  # <ATTENTION>
+      ## Connection string that is used to perform PostgreSQL schema migrations managed by this chart.
+      ## NOTE: Ignored unless `database.connectionString.secretName` and `database.connectionString.migrationConnectionStringKey` parameters are set.
+      ##
+      migrationConnectionString: ""
+      ## Password for the PostgresSQL user that will perform database migrations managed by this chart.
+      ## Pairs with the username set with `database.connectionInfo.migrationUser`.
+      ## NOTE: Ignored if `database.connectionString.secretName` parameter is set or `database.connectionInfo.migrationPasswordKey` is unset.
+      ##
+      migrationConnectionPassword: ""
+
+  database:
+    ## @param secrets.database.connectionString Connection string the service will use when connecting to the PostgresSQL database.
+    ## NOTE: Ignored unless `database.connectionString.secretName` parameter is set.
+    ##
+    connectionString: ""
+    ## @param secrets.database.migrationConnectionString Connection string that is used to perform PostgreSQL schema migrations managed by this chart.
+    ## NOTE: Ignored unless `database.connectionString.secretName` and `database.connectionString.migrationConnectionStringKey` parameters are set.
+    ##
+    migrationConnectionString: ""
+    ## @param secrets.database.connectionPassword Password for the PostgresSQL user the service will use to connect to PostgreSQL.
+    ## Pairs with the username set with `database.connectionInfo.user`.
+    ## NOTE: Ignored if `database.connectionString.secretName` parameter is set.
+    ##
+    connectionPassword: ""
+    ## @param secrets.database.migrationConnectionPassword Password for the PostgresSQL user that will perform database migrations managed by this chart.
+    ## Pairs with the username set with `database.connectionInfo.migrationUser`.
+    ## NOTE: Ignored if `database.connectionString.secretName` parameter is set or `database.connectionInfo.migrationPasswordKey` is unset.
+    ##
+    migrationConnectionPassword: ""
 
 ## Secret configuration for user data
 ##

--- a/getting-started/templates/systemlink-values.yaml
+++ b/getting-started/templates/systemlink-values.yaml
@@ -270,15 +270,21 @@ testmonitorservice:
   ##
   database:
     ## The PostgreSQL database connection string
-    ## NOTE: If specified, the `database.connectionInfo` parameters are ignored.
-    ## If `database.tls.enabled` is set to `true`, the connection string must include the
-    ## appropriate SSL Mode (Prefer or Require).
+    ## NOTE: If specified, the `database.connectionInfo` parameters are ignored. If
+    ## `database.tls.enabled` is set to `true`, the connection string must include the
+    ## appropriate SSL Mode (Prefer, Require, VerifyCA, or VerifyFull).
     # <ATTENTION> - If connecting to an external PostgresSQL database, you must configure one of
     #    the connectionString and connectionInfo sections with the details of your database.
     ##
     connectionString:
       secretName: "testmonitorservicedb-connection"
+      ## Key from the secret to retrieve the connection string the service will use to connect to PostgreSQL.
+      ## NOTE: Ignored unless `database.connectionstring.secretName` parameter is set.
       connectionStringKey: "connection-string"
+      ## Key from the secret to retrieve the connection string that will be used to perform migrations managed by this chart.
+      ## If unset database.connectionString.connectionStringKey is used instead.
+      ## NOTE: Ignored unless `database.connectionstring.secretName` parameter is set.
+      migrationConnectionStringKey: null
     ## The PostgreSQL database connection info.
     ## NOTE: If the `database.connectionString` parameters are specified, the `database.connectionInfo`
     ## parameters are ignored.
@@ -296,13 +302,21 @@ testmonitorservice:
     #     ## PostgreSQL user name.
     #     ##
     #     user: "nisystemlink"
+    #     ## PostgreSQL username used to perform migration managed by this chart.
+    #     ## If unset database.connectionInfo.user is used instead.
+    #     migrationUser: ""
     #     ## The name of an existing secret with PostgreSQL connection credentials.
     #     ##
     #     secretName: "testmonitorservicedb-connection"
-    #     ## Password key to be retrieved from existing secret.
+    #     ## @param database.connectionInfo.passwordKey Password key for database.connectionInfo.user to be retrieved from existing secret
     #     ## NOTE: Ignored unless `database.connectionInfo.secretName` parameter is set.
     #     ##
     #     passwordKey: "password"
+    #     ## @param database.connectionInfo.migrationPasswordKey Password key for database.connectionInfo.migrationUser to be retrieved from existing secret
+    #     ## If unset database.connectionInfo.passwordKey is used instead.
+    #     ## NOTE: Ignored unless `database.connectionInfo.secretName` parameter is set.
+    #     ##
+    #     migrationPasswordKey: null
     ## The PostgreSQL database TLS configuration
     ##
     tls:


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/install-systemlink-enterprise/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Adding the new values that were added in this PR: https://dev.azure.com/ni/DevCentral/_git/Skyline/pullrequest/589182?_a=files&path=/TestMonitorService/helm/values.yaml to the getting started template with documentation.

### Why should this Pull Request be merged?

So that users are aware of the new option of using a separate postgres user for schema migrations.

### What testing has been done?

The helm changes have been tested, this is just updating our template to include the new values.
