### PR TITLE
Add SMTP message limits to values template

### DIFF
--- a/getting-started/templates/systemlink-values.yaml
+++ b/getting-started/templates/systemlink-values.yaml
@@ -909,6 +909,18 @@ smtp:
     ## Optional - The timeout, in seconds, when communicating with the SMTP server.
     ##
     # timeoutSeconds: 100
+  ## Settings related to individual SMTP messages
+  ##
+  messages:
+    ## @param maxRecipients Limit on the number of recipients a single message can be addressed to. Default is 100.
+    ##
+    maxRecipients: "100"
+    ## @param maxBodyBytes Limits the size of the message body. Default is 1 Megabyte.
+    ##
+    maxBodyBytes: "1048576"
+    ## @param maxSubjectBytes Limits the size of the subject line. Default is 10 kilobytes.
+    ##
+    maxSubjectBytes: "10240"
 
 ## Configuration for comments service.
 ##


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/install-systemlink-enterprise/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Make the new SMTP message limit settings user-facing.

### Why should this Pull Request be merged?

Document new settings with potential breaking behavior. This settings are not supported in the November release so these changes should wait until after that release is completed.

### What testing has been done?

N/A
