### PR TITLE
Remove values related to Kafka

### DIFF
--- a/getting-started/templates/systemlink-admin-values.yaml
+++ b/getting-started/templates/systemlink-admin-values.yaml
@@ -16,29 +16,3 @@ global:
   # <ATTENTION> - Set to false if you do not want to manage secrets as part of the Helm installation.
   ##
   deploySecrets: true
-
-## Configuring Strimzi Kafka:
-## https://github.com/strimzi/strimzi-kafka-operator/tree/main/helm-charts/helm3/strimzi-kafka-operator#configuration
-##
-strimzi-kafka-operator:
-  ## <ATTENTION> - Before disabling, review the information in the 2023-10 release
-  ## notes on the procedure for removing Kafka and on when Kafka can safely be disabled.
-  ##
-  enabled: true
-  ## Watch the whole Kubernetes cluster.
-  ##
-  watchAnyNamespace: true
-  podSecurityContext: 
-    runAsNonRoot: true
-  ## Uncomment to set Java heap size
-  ## Only required if the operator is crashing with
-  ## "Terminating due to java.lang.OutOfMemoryError: Java heap space"
-  #extraEnvs:
-  #  - name: JAVA_OPTS
-  #    value: "-Xms256m -Xmx256m"
-
-  ## The registry where kafka images are stored.
-  defaultImageRegistry: *imageRegistryRef
-  ## The secrets required to pull the images.
-  image:
-    imagePullSecrets: *imagePullSecrets

--- a/getting-started/templates/systemlink-values.yaml
+++ b/getting-started/templates/systemlink-values.yaml
@@ -559,23 +559,6 @@ dataframeservice:
       queueSize: 0
 
   ingestion:
-    ## The number of distinct tables using the Kafka ingestion backend that can be appended to before
-    ## table creation will be blocked. To stay under this limit, set 'endOfData: true' on tables that
-    ## don't need to be appended to anymore. For more information, visit ni.com/r/setendofdata.
-    ## Ignored when kafkaBackend.enabled is false.
-    ##
-    appendableTableLimit: 250
-
-    ## Configuration for the Kafka ingestion backend.
-    ##
-    kafkaBackend:
-      ## When true, Kafka and related resources are deployed. When set to false, you must also
-      ## set kafkacluster.kafka.enabled and schema-registry.enabled to false.
-      ## <ATTENTION> - Before disabling the Kafka backend, review the information in
-      ## the 2023-10 release notes on when Kafka can safely be disabled and removed.
-      ##
-      enabled: &kafkaEnabled true
-
     ## Configuration for the pool of streams used to upload the data to S3.
     ##
     s3StreamPool:
@@ -691,39 +674,6 @@ dataframeservice:
             <description>Value can either be true or false, set to true to use SSL with a secure Minio server.</description>
             <value>false</value>
           </property>
-
-  ## Configure Kafka access
-  ##
-  kafkaconnect:
-    spec:
-      template:
-        pod:
-          ## Configure image pull secrets for the Kafka container.
-          ##
-          imagePullSecrets: *pullSecrets
-
-  ## Configure Kafka UI
-  ##
-  kafka-ui:
-    imagePullSecrets:
-      - name: *niPullSecret
-
-  ## Configure the Kafka cluster
-  ##
-  kafkacluster:
-    kafka:
-      ## When false, this resource is not deployed.
-      ## See the documentation for "ingestion.kafkaBackend.enabled" before setting this to false.
-      ##
-      enabled: *kafkaEnabled
-
-  ## Configure Schema Registry for Kafka
-  ##
-  schema-registry:
-    ## When false, this resource is not deployed.
-    ## See the documentation for "ingestion.kafkaBackend.enabled" before setting this to false.
-    ##
-    enabled: *kafkaEnabled
 
 ## Salt configuration.
 ##


### PR DESCRIPTION
- [X] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/install-systemlink-enterprise/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Removes YAML values related to the Kafka operator and DFS Kafka configuration.

### Why should this Pull Request be merged?

The 1.0.0 DFS helm chart removes support for Kafka-based data table ingestion. The 0.20.4 admin chart also removes the Kafka operator. So these values are no longer referenced by anything and should be removed.

### What testing has been done?

Ran a `helm template` command for the latest admin chart using the updated template (with some values filled in for secrets).