### PR TITLE
Document the webserver.oidc.enableLogoutToken value

### DIFF
--- a/getting-started/templates/systemlink-values.yaml
+++ b/getting-started/templates/systemlink-values.yaml
@@ -144,6 +144,11 @@ webserver:
     ## At minimum, "openid" scope is required, "email" and "profile" are required to populate user preferences
     ##
     scope: "openid email profile"
+    ## Optional - Pass the id_token_hint to provider when logging out.
+    ## https://openid.net/specs/openid-connect-rpinitiated-1_0.html#RPLogout
+    ## The id_token_hint parameter is recommended but may cause issues with some identity provider configurations.
+    # <ATTENTION> - Set enableLogoutToken to "true" if the identity provider supports it.
+    enableLogoutToken: "false"
     # Optional - Enable the user-info end-point to return the user's claims
     ##
     # enableUserInfo: "false"


### PR DESCRIPTION
- [ ] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/install-systemlink-enterprise/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

We added a new OIDC configuration parameter as part of supporting ForgeRock as an IdP. This is not a breaking change as the default value gives the same behavior we had previously. We've chosen a safe default because there are known issues with enabling the new behavior with Azure AD, but the new behavior is recommended by the OIDC spec and so we want to document the option and recommend that users enable it if their infrastructure supports it. 

This change applies to the January 2024 release. 

### Why should this Pull Request be merged?

Documenting a setting in the template. 

### What testing has been done?

TODO: Detail what testing has been done to ensure this submission meets requirements.
