### PR TITLE
Add values and secrets of Specification management service

### DIFF
--- a/getting-started/templates/systemlink-secrets.yaml
+++ b/getting-started/templates/systemlink-secrets.yaml
@@ -587,3 +587,21 @@ comments:
       ## Refer to the MongoDB documentation for key generation: https://www.mongodb.com/docs/manual/tutorial/enforce-keyfile-access-control-in-existing-replica-set/#create-a-keyfile
       ##
       replicaSetKey: ""  # <ATTENTION>
+
+## Secret configuration for specification management
+##
+specificationmanagement:
+  secrets:
+    ## Credentials for the MongoDB cluster.
+    ##
+    mongodb:
+      ## Root user password for the database cluster.
+      ##
+      rootPassword: ""  # <ATTENTION>
+      ## Limited user password to allow the service to access the database. This password cannot contain commas or any character that must be escaped in a URL.
+      ##
+      servicePassword: ""  # <ATTENTION>
+      ## Key used to authenticate pods in the database cluster.
+      ## Refer to the MongoDB documentation for key generation: https://www.mongodb.com/docs/manual/tutorial/enforce-keyfile-access-control-in-existing-replica-set/#create-a-keyfile
+      ##
+      replicaSetKey: ""  # <ATTENTION>

--- a/getting-started/templates/systemlink-values.yaml
+++ b/getting-started/templates/systemlink-values.yaml
@@ -902,3 +902,22 @@ comments:
   ## Maximum number of comments supported per delete comments request.
   ##
   maximumCommentsPerDeleteRequest: 1000
+
+## Configuration for specification management service.
+##
+specificationmanagement:
+  ## Maximum number of specifications that can be created per request
+  ##
+  maxSpecificationCreationCountPerRequest: 1000
+
+  ## Maximum number of specifications that can be deleted per request
+  ##
+  maxSpecificationDeletionCountPerRequest: 10000
+
+  ## Maximum number of specifications that can be queried per request
+  ##
+  maxSpecificationQueryCountPerRequest: 10000
+
+  ## Maximum number of specifications that can be updated per request
+  ##
+  maxSpecificationUpdateCountPerRequest: 100

--- a/getting-started/templates/systemlink-values.yaml
+++ b/getting-started/templates/systemlink-values.yaml
@@ -906,18 +906,7 @@ comments:
 ## Configuration for specification management service.
 ##
 specificationmanagement:
-  ## Maximum number of specifications that can be created per request
+  ## <ATTENTION> - Set true to enable the deployment of the Specification Management service and to use its UI.
+  ## By default, this is disabled and the Specification Management service is not deployed.
   ##
-  maxSpecificationCreationCountPerRequest: 1000
-
-  ## Maximum number of specifications that can be deleted per request
-  ##
-  maxSpecificationDeletionCountPerRequest: 10000
-
-  ## Maximum number of specifications that can be queried per request
-  ##
-  maxSpecificationQueryCountPerRequest: 10000
-
-  ## Maximum number of specifications that can be updated per request
-  ##
-  maxSpecificationUpdateCountPerRequest: 100
+  enabled: false


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/install-systemlink-enterprise/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Updates the values.yaml and secrets.yaml templates for Specification Management service which can be configured by the customers.

### Why should this Pull Request be merged?

Customer installing the Specification Management service as part of SystemLink Enterprise can configure the values and secrets if required.

### What testing has been done?

NA
