### PR TITLE
Document encryption key for Systems State Service

### DIFF
--- a/getting-started/templates/systemlink-secrets.yaml
+++ b/getting-started/templates/systemlink-secrets.yaml
@@ -619,6 +619,9 @@ specificationmanagement:
 ##
 systemsstate:
   secrets:
+    ## Cryptographic key to be used for AES-128 encryption of data. This key should have a length of 32 bytes.
+    ##
+    encryptionKey: ""  # <ATTENTION>
     ## Credentials for the MongoDB cluster.
     ##
     mongodb:


### PR DESCRIPTION
- [X] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/install-systemlink-enterprise/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Document the need of an `encryptionKey` for the Systems State service in order to have state content encrypted.

### Why should this Pull Request be merged?

Have documentation for the encryption key needed to have state content encrypted.

### What testing has been done?

The Helm value has been tested on the NI clusters.
