### PR TITLE
Revert "Remove MinIO containerPort config (#188)"

### DIFF
--- a/getting-started/templates/systemlink-values.yaml
+++ b/getting-started/templates/systemlink-values.yaml
@@ -224,6 +224,12 @@ minio:
   auth:
     existingSecret: "minio-credentials"
 
+  ## Port configuration
+  containerPorts:
+    ##  MinIO container port to open for MinIO API
+    ##
+    api: &minioPort 9000
+
   ## Storage configuration.
   persistence:
     ## PVC Storage Request for MinIO data volume


### PR DESCRIPTION
- [X] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/install-systemlink-enterprise/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Reverting 6cf9f01e496b6ec4de0d390082a9cb7ebfaba684, as Bitnami [fixed](https://github.com/bitnami/charts/issues/23953#issuecomment-2011373609) the issue that caused us to want to hide the port configuration. We shouldn't have deleted the anchor declaration anyway -- probably we should have just added an "ATTENTION" callout stating that it should not be changed.

### Why should this Pull Request be merged?

See above.

### What testing has been done?

Reverting to a known-good configuration.
