### PR TITLE
Expose trusted certificates support in helm starter template

### DIFF
--- a/getting-started/templates/systemlink-values.yaml
+++ b/getting-started/templates/systemlink-values.yaml
@@ -96,6 +96,7 @@ global:
     install: false
   ##
   ## Specify secrets containing trusted certificates that should be installed in all the necessary applications.
+  ## The secrets must be deployed manually prior to installing this chart.
   ## Example:
   ##  - secretName: "S3Certificate"
   ##    key: cert
@@ -893,6 +894,7 @@ nbexecservice:
           name: "notebookexecution-s3-credentials"
           key: "password"
         ## Secret PATH containing trusted certificate that should be used for s3 communication.
+        ## The secret must be deployed manually prior to installing this chart.
         # trustedCertificateSecret:
         #   secretName: S3Certificate
         #   key: cert

--- a/getting-started/templates/systemlink-values.yaml
+++ b/getting-started/templates/systemlink-values.yaml
@@ -94,6 +94,12 @@ global:
     #  <ATTENTION> - If you do *not* have your own MongoDB instance set this (`global.mongodb.install`) to `true`.
     ##
     install: false
+  ##
+  ## Specify secrets containing trusted certificates that should be installed in all the necessary applications.
+  ## Example:
+  ##  - secretName: "S3Certificate"
+  ##    key: cert
+  trustedCertificatesSecrets: []
 
 ## Core configuration for the RabbitMQ message broker
 ##
@@ -886,6 +892,10 @@ nbexecservice:
         secretKeySecret:
           name: "notebookexecution-s3-credentials"
           key: "password"
+        ## Secret PATH containing trusted certificate that should be used for s3 communication.
+        # trustedCertificateSecret:
+        #   secretName: S3Certificate
+        #   key: cert
 
 ## Configuration for event-based routine triggering.
 ##


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/install-systemlink-enterprise/blob/master/CONTRIBUTING.md).

TODO: Check the above box with an 'x' indicating you've read and followed [CONTRIBUTING.md](https://github.com/ni/install-systemlink-enterprise/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Expose options to specify trusted certificates in systemlink. 

### Why should this Pull Request be merged?

Custom certificates support was added for s3 communication.

### What testing has been done?

Tested on NI internal cluster.
