### PR TITLE
Revert "Revert "Remove references to generic artifacts (#189)" (#196)"

### DIFF
--- a/getting-started/templates/systemlink-secrets.yaml
+++ b/getting-started/templates/systemlink-secrets.yaml
@@ -61,18 +61,6 @@ secrets:
     ## This cookie is used to authenticate containers in the RabbitMQ stateful set. Use a strong random sequence of characters.
     ##
     erlangCookie: ""  # <ATTENTION>
-  ## Miscellaneous artifact repository credentials.
-  ##
-  genericArtifactPull:
-    ## URL for the repository.
-    ##
-    url: "https://niedge01.jfrog.io/artifactory/ni-generic" # <ATTENTION> - Override if mirroring the SystemLink container registry.
-    ## User for repository access. This will be the same as the image pull credentials.
-    ##
-    user: *imageRegistryUser
-    ## Password for repository access. This will be the same as the image pull credentials.
-    ##
-    password: *imageRegistryPassword
 
 ## Secret configuration for the SystemLink web application.
 ##

--- a/getting-started/templates/systemlink-values.yaml
+++ b/getting-started/templates/systemlink-values.yaml
@@ -25,10 +25,6 @@ global:
   # <ATTENTION> - Use this override if mirroring the SystemLink container registry.
   ##
   imageRegistry: &imageRegistryRef "niedge01.jfrog.io/ni-docker"
-  ##
-  ## Defines a secret containing the credentials for a repo hosting miscellaneous artifacts
-  ##
-  genericArtifactPullSecret: "niartifacts-generic"
   ## Ingress settings that apply globally.
   # <ATTENTION> - Use the following section to apply annotation-based configuration to all Systemlink ingresses.
   #    Configuration is specific to the ingress controller, and the defaults will be sufficient for many deployments.


### PR DESCRIPTION
This reverts commit a8b9fa57353de4fad92902da1b893e0297f18f1f.

- [X] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/install-systemlink-enterprise/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

The issue that caused this change to be initially reverted has been fixed.

### Why should this Pull Request be merged?

The issue that caused this change to be initially reverted has been fixed.

### What testing has been done?

Top-level Helm chart was built with secret removed.
