### PR TITLE
Enable Work Order Service by default

### DIFF
--- a/getting-started/templates/systemlink-values.yaml
+++ b/getting-started/templates/systemlink-values.yaml
@@ -972,8 +972,8 @@ comments:
 ## Configuration for work order service.
 ##
 workorder:
-  ## <ATTENTION> - Set false to disable the deployment of the work order and lab management UI service. 
-  ## By default, this is enabled and the work order and lab management UI service are deployed.
+  ## <ATTENTION> - Set false to disable the deployment of the work order and lab management UI services. 
+  ## By default, this is enabled and the work order and lab management UI services are deployed.
   ##
   enabled: true
 

--- a/getting-started/templates/systemlink-values.yaml
+++ b/getting-started/templates/systemlink-values.yaml
@@ -975,7 +975,7 @@ workorder:
   ## <ATTENTION> - Set false to disable the deployment of the work order and lab management UI service. 
   ## By default, this is enabled and the work order and lab management UI service are deployed.
   ##
-  enabled: false
+  enabled: true
 
 ## Configuration for specification management service.
 ##

--- a/getting-started/templates/systemlink-values.yaml
+++ b/getting-started/templates/systemlink-values.yaml
@@ -972,9 +972,8 @@ comments:
 ## Configuration for work order service.
 ##
 workorder:
-  ## Set to true to enable the deployment of the work order and lab management UI service. By default,
-  ## this is disabled and the work order and lab management UI service are not deployed.
-  ## <ATTENTION> - Set to true to use the work order APIs and lab management UI.
+  ## <ATTENTION> - Set false to disable the deployment of the work order and lab management UI service. 
+  ## By default, this is enabled and the work order and lab management UI service are deployed.
   ##
   enabled: false
 


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/install-systemlink-enterprise/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Enabling the work order service by default as the Landing page shows Test Plans and it should be reachable when clicked on it.

### Why should this Pull Request be merged?

Adds required documentation.

### What testing has been done?

Internal testing.
