### PR TITLE
Remove ttlStrategy from systemlink starter template

### DIFF
--- a/getting-started/templates/systemlink-values.yaml
+++ b/getting-started/templates/systemlink-values.yaml
@@ -840,16 +840,7 @@ argoworkflows:
         registry: *imageRegistryRef
       ## Maximum number of workflows that can run in parallel.
       ##
-      parallelism: 300
-      workflowDefaults:
-        spec:
-          ttlStrategy:
-            ## How long should the workflow live in case of a failure.
-            ##
-            secondsAfterFailure: 600
-            ## How long should the workflow live in case of a success.
-            ##
-            secondsAfterSuccess: 0
+      parallelism: &workflowParallelism 300
     executor:
       image:
         registry: *imageRegistryRef
@@ -860,6 +851,7 @@ argoworkflows:
 ## Configuration for Notebook Execution service.
 ##
 nbexecservice:
+  maxNumberOfWorkflowsToSchedule: *workflowParallelism
   argo:
     ## Configure S3/MinIO access.
     ##


### PR DESCRIPTION
- [X] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/install-systemlink-enterprise/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Update starter-template values for notebook execution

### Why should this Pull Request be merged?

The new helm charts comes with a different ttl strategy, where secondsAfterCompletion is being set to avoid workflows in error state not being cleaned up.

Also those setttings are mentioned in public doc: https://www.ni.com/docs/en-US/bundle/systemlink-enterprise/page/configuring-the-notebook-exectution-service.html

### What testing has been done?

Tested in internal clusters.
