### PR TITLE
Add placeholder secret config for the Alarm Service

### DIFF
--- a/getting-started/templates/systemlink-secrets.yaml
+++ b/getting-started/templates/systemlink-secrets.yaml
@@ -177,6 +177,24 @@ assetservice:
       ##
       replicaSetKey: "" # <ATTENTION>
 
+## Secret configuration for the Alarm Service
+##
+alarmservice:
+  secrets:
+    ## Credentials for the MongoDB cluster.
+    ##
+    mongodb:
+      ## Root user password for the database cluster.
+      ##
+      rootPassword: "" # <ATTENTION>
+      ## Limited user password to allow the service to access the database. This password cannot contain commas or any character that must be escaped in a URL.
+      ##
+      servicePassword: "" # <ATTENTION>
+      ## Key used to authenticate pods in the database cluster.
+      ## Refer to mongodb documentation for key generation: https://www.mongodb.com/docs/manual/tutorial/enforce-keyfile-access-control-in-existing-replica-set/#create-a-keyfile
+      ##
+      replicaSetKey: "" # <ATTENTION>
+
 ## Secret configuration for Grafana dashboard hosting.
 ##
 dashboardhost:

--- a/getting-started/templates/systemlink-values.yaml
+++ b/getting-started/templates/systemlink-values.yaml
@@ -343,6 +343,77 @@ testmonitorservice:
       ##
       certificateSubPath: *postgresCertificateFileName
 
+## Configuration for the Alarm Service
+##
+alarmservice:
+  ## Per-replica rate limiting configuration
+  rateLimits:
+    ## Configuration for the global rate limiter that applies to all requests
+    ## @param rateLimits.global.enabled Enable the rate limiter
+    ## @param rateLimits.global.tokensPerSecond Number of token to replenish per second
+    ## @param rateLimits.global.tokenLimit Maximum number of tokens that can accumulate
+    ## @param rateLimits.global.queueLimit Number of requests that may queue when no tokens are available
+    ##
+    global:
+      enabled: true
+      tokensPerSecond: 750
+      tokenLimit: 200
+      queueLimit: 0
+
+    ## Configuration for the per-user rate limiter for acknowledging alarms
+    ## @param rateLimits.acknowledge.enabled Enable the rate limiter
+    ## @param rateLimits.acknowledge.tokensPerSecond Number of token to replenish per second
+    ## @param rateLimits.acknowledge.tokenLimit Maximum number of tokens that can accumulate
+    ## @param rateLimits.acknowledge.queueLimit Number of requests that may queue when no tokens are available
+    ##
+    acknowledge:
+      enabled: true
+      tokensPerSecond: 5
+      tokenLimit: 5
+      queueLimit: 1
+
+    ## Configuration for the per-API key rate limiter for creating or updating alarms
+    ## @param rateLimits.createOrUpdate.enabled Enable the rate limiter
+    ## @param rateLimits.createOrUpdate.tokensPerSecond Number of token to replenish per second
+    ## @param rateLimits.createOrUpdate.tokenLimit Maximum number of tokens that can accumulate
+    ## @param rateLimits.createOrUpdate.queueLimit Number of requests that may queue when no tokens are available
+    ##
+    createOrUpdate:
+      enabled: true
+      tokensPerSecond: 700
+      tokenLimit: 200
+      queueLimit: 0
+
+    ## Configuration for the per-user rate limiter for deleting alarms
+    ## @param rateLimits.delete.enabled Enable the rate limiter
+    ## @param rateLimits.delete.tokensPerSecond Number of token to replenish per second
+    ## @param rateLimits.delete.tokenLimit Maximum number of tokens that can accumulate
+    ## @param rateLimits.delete.queueLimit Number of requests that may queue when no tokens are available
+    ##
+    delete:
+      enabled: true
+      tokensPerSecond: 10
+      tokenLimit: 10
+      queueLimit: 2
+
+    ## Configuration for the per-user rate limiter for querying alarms
+    ## @param rateLimits.getAndQuery.enabled Enable the rate limiter
+    ## @param rateLimits.getAndQuery.tokensPerSecond Number of token to replenish per second
+    ## @param rateLimits.getAndQuery.tokenLimit Maximum number of tokens that can accumulate
+    ## @param rateLimits.getAndQuery.queueLimit Number of requests that may queue when no tokens are available
+    ##
+    getAndQuery:
+      enabled: true
+      tokensPerSecond: 10
+      tokenLimit: 10
+      queueLimit: 2
+
+  database:
+    ## @param database.inactiveAlarmCleanupInterval The amount of time inactive alarms will
+    ## be retained in the database ([d.]hh:mm[:ss] format).
+    ##
+    inactiveAlarmCleanupInterval: 30.00:00
+
 ## Configuration for the Grafana dashboard provider.
 ##
 dashboardhost:

--- a/getting-started/templates/systemlink-values.yaml
+++ b/getting-started/templates/systemlink-values.yaml
@@ -347,70 +347,90 @@ testmonitorservice:
 ##
 alarmservice:
   ## Per-replica rate limiting configuration
+  ##
   rateLimits:
     ## Configuration for the global rate limiter that applies to all requests
-    ## @param rateLimits.global.enabled Enable the rate limiter
-    ## @param rateLimits.global.tokensPerSecond Number of token to replenish per second
-    ## @param rateLimits.global.tokenLimit Maximum number of tokens that can accumulate
-    ## @param rateLimits.global.queueLimit Number of requests that may queue when no tokens are available
     ##
     global:
+      ## Enable the rate limiter
+      ##
       enabled: true
+      ## Number of token to replenish per second
+      ## 
       tokensPerSecond: 750
+      ## Maximum number of tokens that can accumulate
+      ##
       tokenLimit: 200
+      ## Number of requests that may queue when no tokens are available
+      ##
       queueLimit: 0
 
     ## Configuration for the per-user rate limiter for acknowledging alarms
-    ## @param rateLimits.acknowledge.enabled Enable the rate limiter
-    ## @param rateLimits.acknowledge.tokensPerSecond Number of token to replenish per second
-    ## @param rateLimits.acknowledge.tokenLimit Maximum number of tokens that can accumulate
-    ## @param rateLimits.acknowledge.queueLimit Number of requests that may queue when no tokens are available
     ##
     acknowledge:
+      ## Enable the rate limiter
+      ##
       enabled: true
+      ## Number of token to replenish per second
+      ## 
       tokensPerSecond: 5
+      ## Maximum number of tokens that can accumulate
+      ##
       tokenLimit: 5
+      ## Number of requests that may queue when no tokens are available
+      ##
       queueLimit: 1
 
     ## Configuration for the per-API key rate limiter for creating or updating alarms
-    ## @param rateLimits.createOrUpdate.enabled Enable the rate limiter
-    ## @param rateLimits.createOrUpdate.tokensPerSecond Number of token to replenish per second
-    ## @param rateLimits.createOrUpdate.tokenLimit Maximum number of tokens that can accumulate
-    ## @param rateLimits.createOrUpdate.queueLimit Number of requests that may queue when no tokens are available
     ##
     createOrUpdate:
+      ## Enable the rate limiter
+      ##
       enabled: true
+      ## Number of token to replenish per second
+      ## 
       tokensPerSecond: 700
+      ## Maximum number of tokens that can accumulate
+      ##
       tokenLimit: 200
+      ## Number of requests that may queue when no tokens are available
+      ##
       queueLimit: 0
 
     ## Configuration for the per-user rate limiter for deleting alarms
-    ## @param rateLimits.delete.enabled Enable the rate limiter
-    ## @param rateLimits.delete.tokensPerSecond Number of token to replenish per second
-    ## @param rateLimits.delete.tokenLimit Maximum number of tokens that can accumulate
-    ## @param rateLimits.delete.queueLimit Number of requests that may queue when no tokens are available
     ##
     delete:
+      ## Enable the rate limiter
+      ##
       enabled: true
+      ## Number of token to replenish per second
+      ## 
       tokensPerSecond: 10
+      ## Maximum number of tokens that can accumulate
+      ##
       tokenLimit: 10
+      ## Number of requests that may queue when no tokens are available
+      ##
       queueLimit: 2
 
     ## Configuration for the per-user rate limiter for querying alarms
-    ## @param rateLimits.getAndQuery.enabled Enable the rate limiter
-    ## @param rateLimits.getAndQuery.tokensPerSecond Number of token to replenish per second
-    ## @param rateLimits.getAndQuery.tokenLimit Maximum number of tokens that can accumulate
-    ## @param rateLimits.getAndQuery.queueLimit Number of requests that may queue when no tokens are available
     ##
     getAndQuery:
+      ## Enable the rate limiter
+      ##
       enabled: true
+      ## Number of token to replenish per second
+      ## 
       tokensPerSecond: 10
+      ## Maximum number of tokens that can accumulate
+      ##
       tokenLimit: 10
+      ## Number of requests that may queue when no tokens are available
+      ##
       queueLimit: 2
 
   database:
-    ## @param database.inactiveAlarmCleanupInterval The amount of time inactive alarms will
-    ## be retained in the database ([d.]hh:mm[:ss] format).
+    ## The amount of time inactive alarms will be retained in the database ([d.]hh:mm[:ss] format).
     ##
     inactiveAlarmCleanupInterval: 30.00:00
 


### PR DESCRIPTION
- [X] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/install-systemlink-enterprise/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

- Add placeholder secret config for required secrets.
- Highlight rate limiting config in the top-level values file, for discoverability. We do this for the rate limiting config of other services too.
- Highlight inactive alarm retention config in the top-level values file. Users may want to configure how long inactive alarms remain in the database.

### Why should this Pull Request be merged?

We've added the Alarm Service to the top-level chart, for inclusion in the `2024-06` release, so we should have attention callouts for its required secret config. We typically expose rate limiting config in the top-level values file as well.

### What testing has been done?

None
