### PR TITLE
Update suggested node selector for Dremio

### DIFF
--- a/getting-started/templates/systemlink-values.yaml
+++ b/getting-started/templates/systemlink-values.yaml
@@ -615,9 +615,6 @@ dataframeservice:
   ##
   sldremio:
     ## Uncomment this section to adjust the default tolerations configured for the Dremio pods.
-    ## Allow the negation of taints that have been applied to some set of nodes
-    ## in the Kubernetes cluster so that pods can be scheduled on those tainted nodes.
-    ##
     # tolerations:
     #   - key: "dremio"
     #     operator: "Equal"

--- a/getting-started/templates/systemlink-values.yaml
+++ b/getting-started/templates/systemlink-values.yaml
@@ -614,6 +614,19 @@ dataframeservice:
   ## Configure Dremio access
   ##
   sldremio:
+    ## Uncomment this section to adjust the default tolerations configured for the Dremio pods.
+    ## Allow the negation of taints that have been applied to some set of nodes
+    ## in the Kubernetes cluster so that pods can be scheduled on those tainted nodes.
+    ##
+    # tolerations:
+    #   - key: "dremio"
+    #     operator: "Equal"
+    #     value: "true"
+    #     effect: "NoSchedule"
+    #   - key: "dremio"
+    #     operator: "Equal"
+    #     value: "true"
+    #     effect: "NoExecute"
     ## Uncomment this section to adjust the resource requests for the Dremio executor and coordinator.
     ## Refer to Dremio documentation at https://docs.dremio.com/software/deployment/system-requirements/#server-or-instance-hardware
     ## for a description of the recommended minimum values.
@@ -637,8 +650,10 @@ dataframeservice:
     #   memory: 1024
     #   count: 3
     ## Nodes to select for Dremio pods.
+    ## Note: No node selector is configured by default, but it's recommended to
+    ## configure one to ensure the Dremio pods are scheduled to its tainted nodes.
     # nodeSelector:
-    #   high.mem: "true"
+    #   dremio: "true"
     auth:
       ## Name of the secret containing the Dremio login credentials
       ##


### PR DESCRIPTION
- [X] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/install-systemlink-enterprise/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

- Updates our suggested node selector for Dremio to `dremio:true`, from `high_mem:true`
- Exposes the toleration config, in case customers want to use different node taints

### Why should this Pull Request be merged?

Previously, the Dremio chart tolerated a `high_mem` taint and our public docs suggested a `high.mem` node label. The slight difference in name was confusing for customers and the customer success team. We decided to rename the suggested taint and node label to `dremio` instead, to reduce confusion and better communicate the purpose of the taints and the node selector.

There is no impact to existing customer deployments as a result of this change:

- We've never specified a default node selector for Dremio, we've only ever had a commented-out suggested node selector, which our user-facing [docs](https://www.ni.com/docs/en-US/bundle/systemlink-enterprise/page/configuring-dremio.html) suggested folks configure. Existing node selectors will continue to work. We're updating the user-facing docs to mention the new taint and node label [here](https://dev.azure.com/ni/Users/_git/Documentation%20Reviews/pullrequest/727585).

- We modified the Dremio chart to tolerate both the old and the new taints by default.

### What testing has been done?

We're using the new taints and node selectors in our internal clusters.
