### PR TITLE
Initial AWS Supplemental Values File

### DIFF
--- a/getting-started/templates/AWS/aws_supplemental_values.yml
+++ b/getting-started/templates/AWS/aws_supplemental_values.yml
@@ -78,3 +78,11 @@ swaggerapi:
   ingress:
     annotations:
       alb.ingress.kubernetes.io/healthcheck-path: "/niapis/"
+
+sl-jupyterhub:
+  ingress:
+    annotations:
+      alb.ingress.kubernetes.io/healthcheck-path: "/jupyterhub/hub/health"
+  apiIngress:
+    annotations:
+      alb.ingress.kubernetes.io/healthcheck-path: "/jupyterhub/hub/health"

--- a/getting-started/templates/AWS/aws_supplemental_values.yml
+++ b/getting-started/templates/AWS/aws_supplemental_values.yml
@@ -1,0 +1,63 @@
+global:
+  ingress:
+    api:
+      annotations:
+        alb.ingress.kubernetes.io/healthcheck-path: '/up'
+        # <ATTENTION> - Enter the group name for the API Application Load Balancer
+        alb.ingress.kubernetes.io/group.name: 
+        alb.ingress.kubernetes.io/listen-ports: '[{ "HTTP" : 80 }]'
+        alb.ingress.kubernetes.io/target-group-attributes: 'deregistration_delay.timeout_seconds=300'
+        alb.ingress.kubernetes.io/target-type: 'ip'
+        kubernetes.io/ingress.class: 'alb'
+    ui:
+      annotations:
+        alb.ingress.kubernetes.io/healthcheck-path: '/up'
+        # <ATTENTION> - Enter the group name for the UI (webui) Application Load Balancer
+        alb.ingress.kubernetes.io/group.name: 
+        alb.ingress.kubernetes.io/listen-ports: '[{ "HTTP" : 80 }]'
+        alb.ingress.kubernetes.io/target-group-attributes: 'deregistration_delay.timeout_seconds=300'
+        alb.ingress.kubernetes.io/target-type: 'ip'
+        kubernetes.io/ingress.class: 'alb'
+
+assetservice:
+  ingress:
+    annotations:
+      alb.ingress.kubernetes.io/healthcheck-path: '/niapm/up'
+
+dashboardhost:
+  ingress:
+    annotations:
+      alb.ingress.kubernetes.io/healthcheck-path: '/api/health'
+  apiIngress:
+    annotations:
+      alb.ingress.kubernetes.io/healthcheck-path: '/api/health'
+
+testmonitorservice:
+  ingress:
+    annotations:
+      alb.ingress.kubernetes.io/healthcheck-path: '/nitestmonitor/up'
+
+dataframeservice:
+  ingress:
+    annotations:
+      alb.ingress.kubernetes.io/healthcheck-path: '/nidataframe/health'
+
+saltmaster:
+  serviceTCP:
+    type: NodePort
+    # <ATTENTION> - Enter the ARN for the port 4505 target group
+    elbTargetGroup4505ARN: 
+    # <ATTENTION> - Enter the ARN for the port 4506 target group
+    elbTargetGroup4506ARN: 
+    annotations:
+      service.beta.kubernetes.io/aws-load-balancer-type: 'external'
+
+nbexecservice:
+  ingress:
+    annotations:
+      alb.ingress.kubernetes.io/healthcheck-path: '/ninbexecution/up'
+
+notification:
+  ingress:
+    annotations:
+      alb.ingress.kubernetes.io/healthcheck-path: '/ninotification/up'

--- a/getting-started/templates/AWS/aws_supplemental_values.yml
+++ b/getting-started/templates/AWS/aws_supplemental_values.yml
@@ -65,4 +65,4 @@ notification:
 swaggerapi:
   ingress:
     annotations:
-      alb.ingress.kubernetes.io/healthcheck-path: "/niapis"
+      alb.ingress.kubernetes.io/healthcheck-path: "/niapis/"

--- a/getting-started/templates/AWS/aws_supplemental_values.yml
+++ b/getting-started/templates/AWS/aws_supplemental_values.yml
@@ -5,19 +5,31 @@ global:
         alb.ingress.kubernetes.io/healthcheck-path: "/up"
         # <ATTENTION> - Enter the group name for the API Application Load Balancer
         alb.ingress.kubernetes.io/group.name:
-        alb.ingress.kubernetes.io/listen-ports: '[{ "HTTP" : 80 }]'
         alb.ingress.kubernetes.io/target-group-attributes: "deregistration_delay.timeout_seconds=300"
         alb.ingress.kubernetes.io/target-type: "ip"
         kubernetes.io/ingress.class: "alb"
+        alb.ingress.kubernetes.io/listen-ports: '[{"HTTP":80,"HTTPS": 443}]'
+        # <ATTENTION> - Enter the ARN of the AWS Certificate Manager certificate to associate with this ALB
+        alb.ingress.kubernetes.io/certificate-arn:
+        alb.ingress.kubernetes.io/ssl-policy: "ELBSecurityPolicy-TLS13-1-2-2021-06"
+        alb.ingress.kubernetes.io/actions.ssl-redirect: '{"Type": "redirect", "RedirectConfig": { "Protocol": "HTTPS", "Port": "443", "StatusCode": "HTTP_301"}}'
+        # <ATTENTION> - Optional - Uncomment and enter the ARN for the WAFv2 ACL if you are using AWS' Web Application Firewall
+        # alb.ingress.kubernetes.io/wafv2-acl-arn:
     ui:
       annotations:
         alb.ingress.kubernetes.io/healthcheck-path: "/up"
         # <ATTENTION> - Enter the group name for the UI (webui) Application Load Balancer
         alb.ingress.kubernetes.io/group.name:
-        alb.ingress.kubernetes.io/listen-ports: '[{ "HTTP" : 80 }]'
         alb.ingress.kubernetes.io/target-group-attributes: "deregistration_delay.timeout_seconds=300"
         alb.ingress.kubernetes.io/target-type: "ip"
         kubernetes.io/ingress.class: "alb"
+        alb.ingress.kubernetes.io/listen-ports: '[{"HTTP":80,"HTTPS": 443}]'
+        # <ATTENTION> - Enter the ARN of the AWS Certificate Manager certificate to associate with this ALB
+        alb.ingress.kubernetes.io/certificate-arn:
+        alb.ingress.kubernetes.io/ssl-policy: "ELBSecurityPolicy-TLS13-1-2-2021-06"
+        alb.ingress.kubernetes.io/actions.ssl-redirect: '{"Type": "redirect", "RedirectConfig": { "Protocol": "HTTPS", "Port": "443", "StatusCode": "HTTP_301"}}'
+        # <ATTENTION> - Optional - Uncomment and enter the ARN for the WAFv2 ACL if you are using AWS' Web Application Firewall
+        # alb.ingress.kubernetes.io/wafv2-acl-arn:
 
 assetservice:
   ingress:

--- a/getting-started/templates/AWS/aws_supplemental_values.yml
+++ b/getting-started/templates/AWS/aws_supplemental_values.yml
@@ -2,62 +2,67 @@ global:
   ingress:
     api:
       annotations:
-        alb.ingress.kubernetes.io/healthcheck-path: '/up'
+        alb.ingress.kubernetes.io/healthcheck-path: "/up"
         # <ATTENTION> - Enter the group name for the API Application Load Balancer
-        alb.ingress.kubernetes.io/group.name: 
+        alb.ingress.kubernetes.io/group.name:
         alb.ingress.kubernetes.io/listen-ports: '[{ "HTTP" : 80 }]'
-        alb.ingress.kubernetes.io/target-group-attributes: 'deregistration_delay.timeout_seconds=300'
-        alb.ingress.kubernetes.io/target-type: 'ip'
-        kubernetes.io/ingress.class: 'alb'
+        alb.ingress.kubernetes.io/target-group-attributes: "deregistration_delay.timeout_seconds=300"
+        alb.ingress.kubernetes.io/target-type: "ip"
+        kubernetes.io/ingress.class: "alb"
     ui:
       annotations:
-        alb.ingress.kubernetes.io/healthcheck-path: '/up'
+        alb.ingress.kubernetes.io/healthcheck-path: "/up"
         # <ATTENTION> - Enter the group name for the UI (webui) Application Load Balancer
-        alb.ingress.kubernetes.io/group.name: 
+        alb.ingress.kubernetes.io/group.name:
         alb.ingress.kubernetes.io/listen-ports: '[{ "HTTP" : 80 }]'
-        alb.ingress.kubernetes.io/target-group-attributes: 'deregistration_delay.timeout_seconds=300'
-        alb.ingress.kubernetes.io/target-type: 'ip'
-        kubernetes.io/ingress.class: 'alb'
+        alb.ingress.kubernetes.io/target-group-attributes: "deregistration_delay.timeout_seconds=300"
+        alb.ingress.kubernetes.io/target-type: "ip"
+        kubernetes.io/ingress.class: "alb"
 
 assetservice:
   ingress:
     annotations:
-      alb.ingress.kubernetes.io/healthcheck-path: '/niapm/up'
+      alb.ingress.kubernetes.io/healthcheck-path: "/niapm/up"
 
 dashboardhost:
   ingress:
     annotations:
-      alb.ingress.kubernetes.io/healthcheck-path: '/api/health'
+      alb.ingress.kubernetes.io/healthcheck-path: "/api/health"
   apiIngress:
     annotations:
-      alb.ingress.kubernetes.io/healthcheck-path: '/api/health'
+      alb.ingress.kubernetes.io/healthcheck-path: "/api/health"
 
 testmonitorservice:
   ingress:
     annotations:
-      alb.ingress.kubernetes.io/healthcheck-path: '/nitestmonitor/up'
+      alb.ingress.kubernetes.io/healthcheck-path: "/nitestmonitor/up"
 
 dataframeservice:
   ingress:
     annotations:
-      alb.ingress.kubernetes.io/healthcheck-path: '/nidataframe/health'
+      alb.ingress.kubernetes.io/healthcheck-path: "/nidataframe/health"
 
 saltmaster:
   serviceTCP:
     type: NodePort
     # <ATTENTION> - Enter the ARN for the port 4505 target group
-    elbTargetGroup4505ARN: 
+    elbTargetGroup4505ARN:
     # <ATTENTION> - Enter the ARN for the port 4506 target group
-    elbTargetGroup4506ARN: 
+    elbTargetGroup4506ARN:
     annotations:
-      service.beta.kubernetes.io/aws-load-balancer-type: 'external'
+      service.beta.kubernetes.io/aws-load-balancer-type: "external"
 
 nbexecservice:
   ingress:
     annotations:
-      alb.ingress.kubernetes.io/healthcheck-path: '/ninbexecution/up'
+      alb.ingress.kubernetes.io/healthcheck-path: "/ninbexecution/up"
 
 notification:
   ingress:
     annotations:
-      alb.ingress.kubernetes.io/healthcheck-path: '/ninotification/up'
+      alb.ingress.kubernetes.io/healthcheck-path: "/ninotification/up"
+
+swaggerapi:
+  ingress:
+    annotations:
+      alb.ingress.kubernetes.io/healthcheck-path: "/niapis"


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/install-systemlink-enterprise/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Adds an initial AWS supplemental values file. Customers can pass this file in addition to their other systemlink-values.yml file to set AWS-specific values for the services.

Initially I am tackling two "sets" of supplemental values:

- Setting AWS ALB ingress annotations. Used in conjunction with the suggested Application Load Balancer Controller. Without these AWS Target Groups will not be healthy and allow traffic through.
- saltmaster NLB Target Group ARNs

There are likely other values we would want to inform customers about related to AWS-hosted environments. This is a start.

### Why should this Pull Request be merged?

It's the right thing to do.

### What testing has been done?

Currently having a customer use this for their new AWS-based environment deployment.
