### PR TITLE
Add testmonitor to whitelisted API key list in secrets template

### DIFF
--- a/getting-started/templates/systemlink-secrets.yaml
+++ b/getting-started/templates/systemlink-secrets.yaml
@@ -158,6 +158,9 @@ userservices:
       - serviceName: "routineexecutor"
         key: ""
         hash: "<SHA512 hash of key>"
+      - serviceName: "testmonitor"
+        key: ""
+        hash: "<SHA512 hash of key>"
 
 ## Secret configuration for Asset Management
 ##


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/install-systemlink-enterprise/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

This change adds a testmonitor whitelisted API key placeholder to the set specified in the secrets template.

### Why should this Pull Request be merged?

The testmonitorservice chart now requires a whitelisted API key to the user service, similar to other charts. This requirement is included in July 2024 release.

### What testing has been done?

Template placeholder only change, no testing needed.
