### PR TITLE
Expose alarm limit configuration in the user-facing values file

### DIFF
--- a/getting-started/templates/systemlink-values.yaml
+++ b/getting-started/templates/systemlink-values.yaml
@@ -433,6 +433,29 @@ alarmservice:
     ## The amount of time inactive alarms will be retained in the database ([d.]hh:mm[:ss] format).
     ##
     inactiveAlarmCleanupInterval: 30.00:00
+    
+    activeAlarmCleanup:
+      ## The amount of time active alarms will be retained in the database since they were
+      ## last updated ([d.]hh:mm[:ss] format).
+      ##
+      interval: 90.00:00
+      ## Whether to limit active alarm cleanup to only affect active alarms whose most recent
+      ## transition has a CLEAR transition type.
+      ##
+      onlyCleanUpClearAlarms: false
+  
+  ## The total number of alarms the service supports creating, including
+  ## both active and inactive alarms. Must be greater than activeAlarmLimit.
+  ## The service will return an error if this limit is exceeded. Increasing
+  ## this limit requires tuning of database resources.
+  ##
+  alarmLimit: 100000
+
+  ## The total number of active alarms the service supports creating. Must be less
+  ## than alarmLimit. The service will return an error if this limit is exceeded.
+  ## Increasing this limit requires tuning of database resources.
+  ##
+  activeAlarmLimit: 10000
 
 ## Configuration for the Grafana dashboard provider.
 ##


### PR DESCRIPTION

- [X] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/install-systemlink-enterprise/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

The Alarm Service now enforces limits on the number of alarms that can be created. We've also added a facility to automatically delete active alarms that haven't been updated in a configurable number of days. This PR exposes this configuration in the user-facing values file.

### Why should this Pull Request be merged?

From talking to @prestwick, we think it makes sense to expose the alarm limit and retention configuration in the user-facing values file, as it's something users may want to adjust. We're also going to point to this configuration from our public docs.

### What testing has been done?

I verified the nesting matches what we have in the service's values file.
