### PR TITLE
NbExec | Add S3 configurations to helm

### DIFF
--- a/getting-started/templates/systemlink-values.yaml
+++ b/getting-started/templates/systemlink-values.yaml
@@ -1008,6 +1008,35 @@ argoworkflows:
 ##
 nbexecservice:
   maxNumberOfWorkflowsToSchedule: *workflowParallelism
+  ## Configure S3/MinIO access.
+  ##
+  s3:
+    ## Secret name for S3 credentials.
+    ##
+    secretName: "executions-s3-credentials"
+    ## S3 access type. Supported values are "ACCESS_KEY" and "AWS_WEB_IDENTITY_TOKEN".
+    ##
+    authType: "ACCESS_KEY"
+    ## The name of the S3 or MinIO bucket that the service should connect to.
+    ##
+    bucket: "systemlink-executions"
+    ## S3 connection scheme.
+    ##
+    scheme: "http://"
+    ## Set this value to connect to an external S3 instance.
+    # <ATTENTION> To connect to an external S3 bucket, set the host here as well as the scheme and port.
+    ##
+    host: ""
+    ## Set this value to connect to an S3 instance which is internal to the cluster. Ignored if host is set.
+    ##
+    service: *minioServiceName
+    ## S3 Port
+    # <ATTENTION> This must be overridden if not using the SLE MinIO instance.
+    port: *minioPort
+    ## S3 Region
+    # <ATTENTION> This must be set to the region of the S3 instance.
+    ##
+    region: "us-east-1"
   argo:
     ## Configure S3/MinIO access.
     ##

--- a/getting-started/templates/systemlink-values.yaml
+++ b/getting-started/templates/systemlink-values.yaml
@@ -1013,10 +1013,7 @@ nbexecservice:
   s3:
     ## Secret name for S3 credentials.
     ##
-    secretName: "executions-s3-credentials"
-    ## S3 access type. Supported values are "ACCESS_KEY" and "AWS_WEB_IDENTITY_TOKEN".
-    ##
-    authType: "ACCESS_KEY"
+    secretName: "nbexecservice-s3-credentials"
     ## The name of the S3 or MinIO bucket that the service should connect to.
     ##
     bucket: "systemlink-executions"


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/install-systemlink-enterprise/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Since [S3 buckets are added](https://dev.azure.com/ni/DevCentral/_git/Skyline/pullrequest/771882?_a=files) for nbexecution service, and its [added as mandatory helm variables](https://dev.azure.com/ni/DevCentral/_git/Skyline/pullrequest/769716?_a=files). This PR is adding this new breaking change in getting started.

### Why should this Pull Request be merged?

Adding a new breaking change made in NbExec helm.

### What testing has been done?

NA
