### PR TITLE
Cleanup RabbitMQ recovery documentation

### DIFF
--- a/getting-started/templates/systemlink-values.yaml
+++ b/getting-started/templates/systemlink-values.yaml
@@ -128,15 +128,19 @@ global:
 ##
 rabbitmq:
   ## Policy used when starting pods in the stateful set.
-  # <ATTENTION> - RabbitMQ pods must start in reverse shutdown order.
-  #               To restore the cluster to a healthy state after an unexpected shutdown, temporarily set
-  #               podManagementPolicy to "Parallel" and forceBoot to true.
-  #               https://github.com/bitnami/charts/tree/main/bitnami/rabbitmq#recover-the-cluster-from-complete-shutdown
+  # <ATTENTION> - The "OrderedReady" podManagementPolicy must be used for the first deployment
+  #               of the application. Once the application has been deployed, change the
+  #               podManagementPolicy to "Parallel" to avoid synchronization issues when upgrading
+  #               RabbitMQ instances.
   ##
   podManagementPolicy: "OrderedReady"
   # podManagementPolicy: "Parallel"
   clustering:
     ## Force cluster to boot after an unexpected shutdown (in an unexpected order).
+    # <ATTENTION> - If RabbitMQ fails to restart after an unexpected shutdown, setting foreceBoot to
+    #               true temporarily may resolve the issue. The RabbitMQ maintainers recommend only
+    #               setting this flag to recover from extraordinary circumstances. It should not be used
+    #               for regular application maintenance.
     ##
     forceBoot: false
 

--- a/getting-started/templates/systemlink-values.yaml
+++ b/getting-started/templates/systemlink-values.yaml
@@ -141,6 +141,7 @@ rabbitmq:
     #               true temporarily may resolve the issue. The RabbitMQ maintainers recommend only
     #               setting this flag to recover from extraordinary circumstances. It should not be used
     #               for regular application maintenance.
+    #               https://www.rabbitmq.com/docs/clustering#restarting
     ##
     forceBoot: false
 

--- a/getting-started/templates/systemlink-values.yaml
+++ b/getting-started/templates/systemlink-values.yaml
@@ -131,7 +131,8 @@ rabbitmq:
   # <ATTENTION> - The "OrderedReady" podManagementPolicy must be used for the first deployment
   #               of the application. Once the application has been deployed, change the
   #               podManagementPolicy to "Parallel" to avoid synchronization issues when upgrading
-  #               RabbitMQ instances.
+  #               RabbitMQ instances. It will be necessary to manually delete the rabbitmq stateful
+  #               set from the deployment prior to redeploying with the new setting.
   ##
   podManagementPolicy: "OrderedReady"
   # podManagementPolicy: "Parallel"


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/install-systemlink-enterprise/blob/master/CONTRIBUTING.md)

### What does this Pull Request accomplish?

Bitnami updated their documentation around how to configure their chart to keep a RabbitMQ deployment healthy. I'm updating our user-facing documentation to reflect the latest recommendations.

### Why should this Pull Request be merged?

Updating docs.

### What testing has been done?

N/A
