### PR TITLE
Sizing yaml template for SystemLink Enterprise pilots

### DIFF
--- a/getting-started/templates/pilot-sizing.yaml
+++ b/getting-started/templates/pilot-sizing.yaml
@@ -9,10 +9,6 @@
 # with the following node topology:
 # 4 nodes - 8 CPU, 32 GB memory - General node pool
 # 2 nodes - 8 CPU, 32 GB memory - Dedicated for Dremio
-
-# Two replicas are used for most services for increased performance.
-# The Mongo databases are reduced to a single replica and as a result,
-# does not provide any high availability.
 #
 # This is a YAML-formatted file.
 
@@ -51,18 +47,6 @@ assetservice:
     targetCPUUtilizationPercentage: 60
     targetMemoryUtilizationPercentage: 70
 
-  mongodb:
-    architecture: replicaset
-    replicaCount: 1
-    resources:
-      requests:
-        cpu: 150m
-        memory: 512Mi
-      limits:
-        memory: 1024Mi
-    persistence:
-      size: 1Gi
-
 assetui:
   resources:
     requests:
@@ -72,8 +56,8 @@ assetui:
       memory: "20Mi"
 
   autoscaling:
-    minReplicas: 2
-    maxReplicas: 2
+    minReplicas: 1
+    maxReplicas: 1
     targetCPUUtilizationPercentage: 80
     targetMemoryUtilizationPercentage: 90
 
@@ -91,18 +75,6 @@ comments:
     maxReplicas: 2
     targetCPUUtilizationPercentage: 60
     targetMemoryUtilizationPercentage: 70
-
-  mongodb:
-    architecture: replicaset
-    replicaCount: 1
-    resources:
-      requests:
-        cpu: 150m
-        memory: 512Mi
-      limits:
-        memory: 1024Mi
-    persistence:
-      size: 1Gi
 
 dashboardhost:
   autoscaling:
@@ -134,8 +106,8 @@ dashboardsui:
       memory: "20Mi"
 
   autoscaling:
-    minReplicas: 2
-    maxReplicas: 2
+    minReplicas: 1
+    maxReplicas: 1
     targetCPUUtilizationPercentage: 80
     targetMemoryUtilizationPercentage: 90
 
@@ -154,16 +126,6 @@ dataframeservice:
     targetCPUUtilizationPercentage: 60
     targetMemoryUtilizationPercentage: 70
 
-  mongodb:
-    architecture: replicaset
-    replicaCount: 1
-    resources:
-      requests:
-        cpu: "150m"
-        memory: "256Mi"
-      limits:
-        memory: "256Mi"
-
 executionsui:
   resources:
     requests:
@@ -173,8 +135,8 @@ executionsui:
       memory: "20Mi"
 
   autoscaling:
-    minReplicas: 2
-    maxReplicas: 2
+    minReplicas: 1
+    maxReplicas: 1
     targetCPUUtilizationPercentage: 80
     targetMemoryUtilizationPercentage: 90
 
@@ -193,18 +155,6 @@ feedservice:
     targetCPUUtilizationPercentage: 60
     targetMemoryUtilizationPercentage: 70
 
-  mongodb:
-    architecture: replicaset
-    replicaCount: 1
-    resources:
-      requests:
-        cpu: 150m
-        memory: 512Mi
-      limits:
-        memory: 1024Mi
-    persistence:
-      size: 1Gi
-
 fileingestion:
   resources:
     requests:
@@ -219,18 +169,6 @@ fileingestion:
     targetCPUUtilizationPercentage: 80
     targetMemoryUtilizationPercentage: 90
 
-  mongodb:
-    architecture: replicaset
-    replicaCount: 1
-    resources:
-      requests:
-        cpu: 150m
-        memory: 256Mi
-      limits:
-        memory: 1024Mi
-    persistence:
-      size: 1Gi
-
 filesui:
   resources:
     requests:
@@ -240,8 +178,8 @@ filesui:
       memory: "20Mi"
 
   autoscaling:
-    minReplicas: 2
-    maxReplicas: 2
+    minReplicas: 1
+    maxReplicas: 1
     targetCPUUtilizationPercentage: 80
     targetMemoryUtilizationPercentage: 90
 
@@ -254,8 +192,8 @@ landingpageui:
       memory: "20Mi"
 
   autoscaling:
-    minReplicas: 2
-    maxReplicas: 2
+    minReplicas: 1
+    maxReplicas: 1
     targetCPUUtilizationPercentage: 80
     targetMemoryUtilizationPercentage: 90
 
@@ -294,18 +232,6 @@ nbexecservice:
     targetCPUUtilizationPercentage: 80
     targetMemoryUtilizationPercentage: 90
 
-  mongodb:
-    architecture: replicaset
-    replicaCount: 1
-    resources:
-      requests:
-        cpu: 150m
-        memory: 256Mi
-      limits:
-        memory: 1024Mi
-    persistence:
-      size: 1Gi
-
 nbparsingservice:
   resources:
     requests:
@@ -335,18 +261,6 @@ notification:
     targetCPUUtilizationPercentage: 60
     targetMemoryUtilizationPercentage: 70
 
-  mongodb:
-    architecture: replicaset
-    replicaCount: 1
-    resources:
-      requests:
-        cpu: 150m
-        memory: 512Mi
-      limits:
-        memory: 1024Mi
-    persistence:
-      size: 1Gi
-
 rabbitmq:
   resources:
     requests:
@@ -370,18 +284,6 @@ repository:
     targetCPUUtilizationPercentage: 60
     targetMemoryUtilizationPercentage: 70
 
-  mongodb:
-    architecture: replicaset
-    replicaCount: 1
-    resources:
-      requests:
-        cpu: 150m
-        memory: 512Mi
-      limits:
-        memory: 1024Mi
-    persistence:
-      size: 1Gi
-
 routineeventtrigger:
   resources:
     requests:
@@ -389,7 +291,6 @@ routineeventtrigger:
       cpu: 100m
     limits:
       memory: "512Mi"
-
   replicaCount: 1
 
 routineexecutor:
@@ -414,20 +315,7 @@ routinescheduletrigger:
       cpu: 100m
     limits:
       memory: "512Mi"
-
   replicaCount: 1
-
-  mongodb:
-    architecture: replicaset
-    replicaCount: 1
-    resources:
-      requests:
-        cpu: 150m
-        memory: 512Mi
-      limits:
-        memory: 1024Mi
-    persistence:
-      size: 1Gi
 
 routineservice:
   resources:
@@ -442,18 +330,6 @@ routineservice:
     maxReplicas: 2
     targetCPUUtilizationPercentage: 80
     targetMemoryUtilizationPercentage: 90
-
-  mongodb:
-    architecture: replicaset
-    replicaCount: 1
-    resources:
-      requests:
-        cpu: 150m
-        memory: 256Mi
-      limits:
-        memory: 1024Mi
-    persistence:
-      size: 1Gi
 
   engine:
     replicaCount: 1
@@ -473,8 +349,8 @@ routinesui:
       memory: "20Mi"
 
   autoscaling:
-    minReplicas: 2
-    maxReplicas: 2
+    minReplicas: 1
+    maxReplicas: 1
     targetCPUUtilizationPercentage: 80
     targetMemoryUtilizationPercentage: 90
 
@@ -493,18 +369,6 @@ saltmaster:
     targetCPUUtilizationPercentage: 60
     targetMemoryUtilizationPercentage: 70
 
-  mongodb:
-    architecture: replicaset
-    replicaCount: 1
-    resources:
-      requests:
-        cpu: 150m
-        memory: 512Mi
-      limits:
-        memory: 1024Mi
-    persistence:
-      size: 1Gi
-
 securityui:
   resources:
     requests:
@@ -514,8 +378,8 @@ securityui:
       memory: "20Mi"
 
   autoscaling:
-    minReplicas: 2
-    maxReplicas: 2
+    minReplicas: 1
+    maxReplicas: 1
     targetCPUUtilizationPercentage: 80
     targetMemoryUtilizationPercentage: 90
 
@@ -582,8 +446,8 @@ swaggerapi:
 
   autoscaling:
     enabled: true
-    minReplicas: 2
-    maxReplicas: 2
+    minReplicas: 1
+    maxReplicas: 1
     targetCPUUtilizationPercentage: 60
     targetMemoryUtilizationPercentage: 70
 
@@ -602,18 +466,6 @@ sysmgmtevent:
     targetCPUUtilizationPercentage: 60
     targetMemoryUtilizationPercentage: 70
 
-  mongodb:
-    architecture: replicaset
-    replicaCount: 1
-    resources:
-      requests:
-        cpu: 150m
-        memory: 512Mi
-      limits:
-        memory: 1024Mi
-    persistence:
-      size: 1Gi
-
 systems:
   resources:
     requests:
@@ -626,18 +478,6 @@ systems:
     enabled: true
     minReplicas: 2
     maxReplicas: 2
-
-  mongodb:
-    architecture: replicaset
-    replicaCount: 1
-    resources:
-      requests:
-        cpu: 150m
-        memory: 256Mi
-      limits:
-        memory: 1024Mi
-    persistence:
-      size: 1Gi
 
 systemsstate:
   resources:
@@ -663,8 +503,8 @@ systemsui:
       memory: "20Mi"
 
   autoscaling:
-    minReplicas: 2
-    maxReplicas: 2
+    minReplicas: 1
+    maxReplicas: 1
     targetCPUUtilizationPercentage: 80
     targetMemoryUtilizationPercentage: 90
 
@@ -683,18 +523,6 @@ tags:
     targetCPUUtilizationPercentage: 60
     targetMemoryUtilizationPercentage: 70
 
-  mongodb:
-    architecture: replicaset
-    replicaCount: 1
-    resources:
-      requests:
-        cpu: 150m
-        memory: 512Mi
-      limits:
-        memory: 1024Mi
-    persistence:
-      size: 1Gi
-
 taghistorian:
   resources:
     requests:
@@ -709,18 +537,6 @@ taghistorian:
     maxReplicas: 2
     targetCPUUtilizationPercentage: 60
     targetMemoryUtilizationPercentage: 70
-
-  mongodb:
-    architecture: replicaset
-    replicaCount: 1
-    resources:
-      requests:
-        cpu: 150m
-        memory: 512Mi
-      limits:
-        memory: 1024Mi
-    persistence:
-      size: 1Gi
 
   dataRetention:
     resources:
@@ -746,8 +562,8 @@ testinsightsui:
       memory: "20Mi"
 
   autoscaling:
-    minReplicas: 2
-    maxReplicas: 2
+    minReplicas: 1
+    maxReplicas: 1
     targetCPUUtilizationPercentage: 80
     targetMemoryUtilizationPercentage: 90
 
@@ -779,18 +595,6 @@ userdata:
     targetCPUUtilizationPercentage: 80
     targetMemoryUtilizationPercentage: 90
 
-  mongodb:
-    architecture: replicaset
-    replicaCount: 1
-    resources:
-      requests:
-        cpu: 150m
-        memory: 256Mi
-      limits:
-        memory: 1024Mi
-    persistence:
-      size: 1Gi
-
 userservices:
   resources:
     requests:
@@ -805,18 +609,6 @@ userservices:
     targetCPUUtilizationPercentage: 80
     targetMemoryUtilizationPercentage: 90
 
-  mongodb:
-    architecture: replicaset
-    replicaCount: 1
-    resources:
-      requests:
-        cpu: 150m
-        memory: 256Mi
-      limits:
-        memory: 1024Mi
-    persistence:
-      size: 1Gi
-
 webappservices:
   resources:
     requests:
@@ -830,18 +622,6 @@ webappservices:
     maxReplicas: 2
     targetCPUUtilizationPercentage: 80
     targetMemoryUtilizationPercentage: 90
-
-  mongodb:
-    architecture: replicaset
-    replicaCount: 1
-    resources:
-      requests:
-        cpu: 150m
-        memory: 256Mi
-      limits:
-        memory: 1024Mi
-    persistence:
-      size: 1Gi
 
 webserver:
   resources:
@@ -881,15 +661,3 @@ workorder:
     maxReplicas: 2
     targetCPUUtilizationPercentage: 60
     targetMemoryUtilizationPercentage: 70
-
-  mongodb:
-    architecture: replicaset
-    replicaCount: 1
-    resources:
-      requests:
-        cpu: 150m
-        memory: 512Mi
-      limits:
-        memory: 1024Mi
-    persistence:
-      size: 1Gi

--- a/getting-started/templates/pilot-sizing.yaml
+++ b/getting-started/templates/pilot-sizing.yaml
@@ -1,6 +1,20 @@
-# Default values for SystemLink pilot resources and replicas.
+# Value overrides for SystemLink pilot resources and replicas.
+#
+# Use this file in addition to the `systemlink-values.yaml` to
+# customize the SystemLink deployment for small pilot clusters.
+#
+# This file reduces the number of service replicas and pod CPU and
+# memory requests such that the application can deploy with fewer
+# kubernetes cluster nodes. The cluster is intended to be deployed
+# with the following node topology:
+# 4 nodes - 8 CPU, 32 GB memory - General node pool
+# 2 nodes - 8 CPU, 32 GB memory - Dedicated for Dremio
+
+# Two replicas are used for most services for increased performance.
+# The Mongo databases are reduced to a single replica and as a result,
+# does not provide any high availability.
+#
 # This is a YAML-formatted file.
-# Declare override values for variables.
 
 alarmservice:
   resources:

--- a/getting-started/templates/pilot-sizing.yaml
+++ b/getting-started/templates/pilot-sizing.yaml
@@ -1,0 +1,891 @@
+# Default values for SystemLink pilot resources and replicas.
+# This is a YAML-formatted file.
+# Declare override values for variables.
+
+rabbitmq:
+  resources:
+    requests:
+      cpu: "100m"
+      memory: "256Mi"
+    limits:
+      memory: "512Mi"
+
+minio:
+  persistence:
+    size: 1Gi
+  provisioning:
+    enabled: true
+    buckets:
+      - name: "systemlink-file-ingestion"
+        region: "us-east-1"
+        versioning: false
+        withLock: false
+      - name: "systemlink-dataframe"
+        region: "us-east-1"
+        versioning: false
+        withLock: false
+  resources:
+    requests:
+      memory: "256Mi"
+      cpu: "50m"
+    limits:
+      memory: "512Mi"
+
+webserver:
+  resources:
+    requests:
+      memory: "128Mi"
+      cpu: "50m"
+    limits:
+      memory: "256Mi"
+
+  autoscaling:
+    minReplicas: 2
+    maxReplicas: 2
+    targetCPUUtilizationPercentage: 80
+    targetMemoryUtilizationPercentage: 90
+
+  redis-cluster:
+    cluster:
+      nodes: 3
+      replicas: 0
+    redis:
+      resources:
+        requests:
+          cpu: 50m
+        limits:
+
+sessionmanager:
+  resources:
+    requests:
+      memory: "64Mi"
+      cpu: "50m"
+    limits:
+      memory: "128Mi"
+
+  autoscaling:
+    minReplicas: 2
+    maxReplicas: 2
+    targetCPUUtilizationPercentage: 80
+    targetMemoryUtilizationPercentage: 90
+
+testmonitorservice:
+  resources:
+    requests:
+      memory: "256Mi"
+      cpu: "100m"
+    limits:
+      memory: "512Mi"
+
+  autoscaling:
+    minReplicas: 2
+    maxReplicas: 2
+    targetCPUUtilizationPercentage: 80
+    targetMemoryUtilizationPercentage: 90
+
+dashboardhost:
+  autoscaling:
+    minReplicas: 2
+    maxReplicas: 2
+    targetCPUUtilizationPercentage: 80
+    targetMemoryUtilizationPercentage: 90
+
+  grafana:
+    autoscaling:
+      minReplicas: 2
+      maxReplicas: 2
+      metrics:
+      - type: Resource
+        resource:
+          name: cpu
+          targetAverageUtilization: 80
+      - type: Resource
+        resource:
+          name: memory
+          targetAverageUtilization: 90
+
+dataframeservice:
+  resources:
+    requests:
+      memory: 512Mi
+      cpu: 100m
+    limits:
+      memory: 512Mi
+
+  autoscaling:
+    enabled: true
+    minReplicas: 2
+    maxReplicas: 2
+    targetCPUUtilizationPercentage: 60
+    targetMemoryUtilizationPercentage: 70
+
+  mongodb:
+    architecture: replicaset
+    replicaCount: 1
+    resources:
+      requests:
+        cpu: "150m"
+        memory: "256Mi"
+      limits:
+        memory: "256Mi"
+
+saltmaster:
+  replicaCount: 1
+  resources:
+    requests:
+      memory: 256Mi
+      cpu: 150m
+    limits:
+      memory: 512Mi
+
+fileingestion:
+  resources:
+    requests:
+      memory: "128Mi"
+      cpu: "50m"
+    limits:
+      memory: "256Mi"
+
+  autoscaling:
+    minReplicas: 2
+    maxReplicas: 2
+    targetCPUUtilizationPercentage: 80
+    targetMemoryUtilizationPercentage: 90
+
+  mongodb:
+    architecture: replicaset
+    replicaCount: 1
+    resources:
+      requests:
+        cpu: 150m
+        memory: 256Mi
+      limits:
+        memory: 1024Mi
+    persistence:
+      size: 1Gi
+
+
+nbexecservice:
+  resources:
+    requests:
+      memory: "256Mi"
+      cpu: "100m"
+    limits:
+      memory: "512Mi"
+
+  autoscaling:
+    minReplicas: 2
+    maxReplicas: 2
+    targetCPUUtilizationPercentage: 80
+    targetMemoryUtilizationPercentage: 90
+
+  mongodb:
+    architecture: replicaset
+    replicaCount: 1
+    resources:
+      requests:
+        cpu: 150m
+        memory: 256Mi
+      limits:
+        memory: 1024Mi
+    persistence:
+      size: 1Gi
+
+nbparsingservice:
+  resources:
+    requests:
+      memory: "256Mi"
+      cpu: "100m"
+    limits:
+      memory: "512Mi"
+
+  autoscaling:
+    minReplicas: 2
+    maxReplicas: 2
+    targetCPUUtilizationPercentage: 80
+    targetMemoryUtilizationPercentage: 90
+
+userservices:
+  resources:
+    requests:
+      memory: "64Mi"
+      cpu: "50m"
+    limits:
+      memory: "128Mi"
+
+  autoscaling:
+    minReplicas: 2
+    maxReplicas: 2
+    targetCPUUtilizationPercentage: 80
+    targetMemoryUtilizationPercentage: 90
+
+  mongodb:
+    architecture: replicaset
+    replicaCount: 1
+    resources:
+      requests:
+        cpu: 150m
+        memory: 256Mi
+      limits:
+        memory: 1024Mi
+    persistence:
+      size: 1Gi
+
+webappservices:
+  resources:
+    requests:
+      memory: "64Mi"
+      cpu: "50m"
+    limits:
+      memory: "128Mi"
+
+  autoscaling:
+    minReplicas: 2
+    maxReplicas: 2
+    targetCPUUtilizationPercentage: 80
+    targetMemoryUtilizationPercentage: 90
+
+  mongodb:
+    architecture: replicaset
+    replicaCount: 1
+    resources:
+      requests:
+        cpu: 150m
+        memory: 256Mi
+      limits:
+        memory: 1024Mi
+    persistence:
+      size: 1Gi
+
+serviceregistry:
+  resources:
+    requests:
+      memory: "256Mi"
+      cpu: "50m"
+    limits:
+      memory: "256Mi"
+
+  autoscaling:
+    minReplicas: 2
+    maxReplicas: 2
+    targetCPUUtilizationPercentage: 80
+    targetMemoryUtilizationPercentage: 90
+
+securityui:
+  resources:
+    requests:
+      memory: "10Mi"
+      cpu: "4m"
+    limits:
+      memory: "20Mi"
+
+  autoscaling:
+    minReplicas: 2
+    maxReplicas: 2
+    targetCPUUtilizationPercentage: 80
+    targetMemoryUtilizationPercentage: 90
+
+dashboardsui:
+  resources:
+    requests:
+      memory: "10Mi"
+      cpu: "4m"
+    limits:
+      memory: "20Mi"
+
+  autoscaling:
+    minReplicas: 2
+    maxReplicas: 2
+    targetCPUUtilizationPercentage: 80
+    targetMemoryUtilizationPercentage: 90
+
+filesui:
+  resources:
+    requests:
+      memory: "10Mi"
+      cpu: "4m"
+    limits:
+      memory: "20Mi"
+
+  autoscaling:
+    minReplicas: 2
+    maxReplicas: 2
+    targetCPUUtilizationPercentage: 80
+    targetMemoryUtilizationPercentage: 90
+
+landingpageui:
+  resources:
+    requests:
+      memory: "10Mi"
+      cpu: "4m"
+    limits:
+      memory: "20Mi"
+
+  autoscaling:
+    minReplicas: 2
+    maxReplicas: 2
+    targetCPUUtilizationPercentage: 80
+    targetMemoryUtilizationPercentage: 90
+
+testinsightsui:
+  resources:
+    requests:
+      memory: "10Mi"
+      cpu: "4m"
+    limits:
+      memory: "20Mi"
+
+  autoscaling:
+    minReplicas: 2
+    maxReplicas: 2
+    targetCPUUtilizationPercentage: 80
+    targetMemoryUtilizationPercentage: 90
+
+systemsui:
+  resources:
+    requests:
+      memory: "10Mi"
+      cpu: "4m"
+    limits:
+      memory: "20Mi"
+
+  autoscaling:
+    minReplicas: 2
+    maxReplicas: 2
+    targetCPUUtilizationPercentage: 80
+    targetMemoryUtilizationPercentage: 90
+
+executionsui:
+  resources:
+    requests:
+      memory: "10Mi"
+      cpu: "4m"
+    limits:
+      memory: "20Mi"
+
+  autoscaling:
+    minReplicas: 2
+    maxReplicas: 2
+    targetCPUUtilizationPercentage: 80
+    targetMemoryUtilizationPercentage: 90
+
+userdata:
+  resources:
+    requests:
+      memory: "64Mi"
+      cpu: "25m"
+    limits:
+      memory: "128Mi"
+
+  autoscaling:
+    minReplicas: 2
+    maxReplicas: 2
+    targetCPUUtilizationPercentage: 80
+    targetMemoryUtilizationPercentage: 90
+
+  mongodb:
+    architecture: replicaset
+    replicaCount: 1
+    resources:
+      requests:
+        cpu: 150m
+        memory: 256Mi
+      limits:
+        memory: 1024Mi
+    persistence:
+      size: 1Gi
+
+routinesui:
+  resources:
+    requests:
+      memory: "10Mi"
+      cpu: "4m"
+    limits:
+      memory: "20Mi"
+
+  autoscaling:
+    minReplicas: 2
+    maxReplicas: 2
+    targetCPUUtilizationPercentage: 80
+    targetMemoryUtilizationPercentage: 90
+
+routineservice:
+  resources:
+    requests:
+      memory: "128Mi"
+      cpu: "50m"
+    limits:
+      memory: "256Mi"
+
+  autoscaling:
+    minReplicas: 2
+    maxReplicas: 2
+    targetCPUUtilizationPercentage: 80
+    targetMemoryUtilizationPercentage: 90
+
+  mongodb:
+    architecture: replicaset
+    replicaCount: 1
+    resources:
+      requests:
+        cpu: 150m
+        memory: 256Mi
+      limits:
+        memory: 1024Mi
+    persistence:
+      size: 1Gi
+
+  engine:
+    replicaCount: 1
+    resources:
+      requests:
+        memory: "25Mi"
+        cpu: "4m"
+      limits:
+        memory: "50Mi"
+
+sl-jupyterhub:
+  jupyterhub:
+    hub:
+      resources:
+        requests:
+          memory: "128Mi"
+          cpu: "100m"
+        limits:
+          memory: "256Mi"
+
+systems:
+  resources:
+    requests:
+      memory: "128Mi"
+      cpu: "50m"
+    limits:
+      memory: "256Mi"
+
+  autoscaling:
+    enabled: true
+    minReplicas: 2
+    maxReplicas: 2
+
+  mongodb:
+    architecture: replicaset
+    replicaCount: 1
+    resources:
+      requests:
+        cpu: 150m
+        memory: 256Mi
+      limits:
+        memory: 1024Mi
+    persistence:
+      size: 1Gi
+
+assetservice:
+  resources:
+    requests:
+      cpu: 100m
+      memory: 256Mi
+    limits:
+      memory: 512Mi
+
+  autoscaling:
+    enabled: true
+    minReplicas: 2
+    maxReplicas: 2
+    targetCPUUtilizationPercentage: 60
+    targetMemoryUtilizationPercentage: 70
+
+  mongodb:
+    architecture: replicaset
+    replicaCount: 1
+    resources:
+      requests:
+        cpu: 150m
+        memory: 512Mi
+      limits:
+        memory: 1024Mi
+    persistence:
+      size: 1Gi
+
+assetui:
+  resources:
+    requests:
+      memory: "10Mi"
+      cpu: "4m"
+    limits:
+      memory: "20Mi"
+
+  autoscaling:
+    minReplicas: 2
+    maxReplicas: 2
+    targetCPUUtilizationPercentage: 80
+    targetMemoryUtilizationPercentage: 90
+
+sysmgmtevent:
+  resources:
+    requests:
+      memory: "256Mi"
+      cpu: 100m
+    limits:
+      memory: "512Mi"
+
+  autoscaling:
+    enabled: true
+    minReplicas: 2
+    maxReplicas: 2
+    targetCPUUtilizationPercentage: 60
+    targetMemoryUtilizationPercentage: 70
+
+  mongodb:
+    architecture: replicaset
+    replicaCount: 1
+    resources:
+      requests:
+        cpu: 150m
+        memory: 512Mi
+      limits:
+        memory: 1024Mi
+    persistence:
+      size: 1Gi
+
+comments:
+  resources:
+    requests:
+      memory: "256Mi"
+      cpu: 100m
+    limits:
+      memory: "512Mi"
+
+  autoscaling:
+    enabled: true
+    minReplicas: 2
+    maxReplicas: 2
+    targetCPUUtilizationPercentage: 60
+    targetMemoryUtilizationPercentage: 70
+
+  mongodb:
+    architecture: replicaset
+    replicaCount: 1
+    resources:
+      requests:
+        cpu: 150m
+        memory: 512Mi
+      limits:
+        memory: 1024Mi
+    persistence:
+      size: 1Gi
+
+notification:
+  resources:
+    requests:
+      memory: "256Mi"
+      cpu: 100m
+    limits:
+      memory: "512Mi"
+
+  autoscaling:
+    enabled: true
+    minReplicas: 2
+    maxReplicas: 2
+    targetCPUUtilizationPercentage: 60
+    targetMemoryUtilizationPercentage: 70
+
+  mongodb:
+    architecture: replicaset
+    replicaCount: 1
+    resources:
+      requests:
+        cpu: 150m
+        memory: 512Mi
+      limits:
+        memory: 1024Mi
+    persistence:
+      size: 1Gi
+
+repository:
+  resources:
+    requests:
+      memory: "256Mi"
+      cpu: 100m
+    limits:
+      memory: "512Mi"
+
+  autoscaling:
+    enabled: true
+    minReplicas: 2
+    maxReplicas: 2
+    targetCPUUtilizationPercentage: 60
+    targetMemoryUtilizationPercentage: 70
+
+  mongodb:
+    architecture: replicaset
+    replicaCount: 1
+    resources:
+      requests:
+        cpu: 150m
+        memory: 512Mi
+      limits:
+        memory: 1024Mi
+    persistence:
+      size: 1Gi
+
+routineeventtrigger:
+  resources:
+    requests:
+      memory: "256Mi"
+      cpu: 100m
+    limits:
+      memory: "512Mi"
+
+  replicaCount: 1
+
+routineexecutor:
+  resources:
+    requests:
+      memory: "256Mi"
+      cpu: 100m
+    limits:
+      memory: "512Mi"
+
+  autoscaling:
+    enabled: true
+    minReplicas: 2
+    maxReplicas: 2
+    targetCPUUtilizationPercentage: 60
+    targetMemoryUtilizationPercentage: 70
+
+routinescheduletrigger:
+  resources:
+    requests:
+      memory: "256Mi"
+      cpu: 100m
+    limits:
+      memory: "512Mi"
+
+  replicaCount: 1
+
+  mongodb:
+    architecture: replicaset
+    replicaCount: 1
+    resources:
+      requests:
+        cpu: 150m
+        memory: 512Mi
+      limits:
+        memory: 1024Mi
+    persistence:
+      size: 1Gi
+
+saltmaster:
+  resources:
+    requests:
+      memory: "256Mi"
+      cpu: 100m
+    limits:
+      memory: "512Mi"
+
+  autoscaling:
+    enabled: true
+    minReplicas: 2
+    maxReplicas: 2
+    targetCPUUtilizationPercentage: 60
+    targetMemoryUtilizationPercentage: 70
+
+  mongodb:
+    architecture: replicaset
+    replicaCount: 1
+    resources:
+      requests:
+        cpu: 150m
+        memory: 512Mi
+      limits:
+        memory: 1024Mi
+    persistence:
+      size: 1Gi
+
+smtp:
+  resources:
+    requests:
+      memory: "256Mi"
+      cpu: 100m
+    limits:
+      memory: "512Mi"
+
+  autoscaling:
+    enabled: true
+    minReplicas: 2
+    maxReplicas: 2
+    targetCPUUtilizationPercentage: 60
+    targetMemoryUtilizationPercentage: 70
+
+swaggerapi:
+  resources:
+    requests:
+      memory: "256Mi"
+      cpu: 100m
+    limits:
+      memory: "512Mi"
+
+  autoscaling:
+    enabled: true
+    minReplicas: 2
+    maxReplicas: 2
+    targetCPUUtilizationPercentage: 60
+    targetMemoryUtilizationPercentage: 70
+
+tags:
+  resources:
+    requests:
+      memory: "256Mi"
+      cpu: 100m
+    limits:
+      memory: "512Mi"
+
+  autoscaling:
+    enabled: true
+    minReplicas: 2
+    maxReplicas: 2
+    targetCPUUtilizationPercentage: 60
+    targetMemoryUtilizationPercentage: 70
+
+  mongodb:
+    architecture: replicaset
+    replicaCount: 1
+    resources:
+      requests:
+        cpu: 150m
+        memory: 512Mi
+      limits:
+        memory: 1024Mi
+    persistence:
+      size: 1Gi
+
+taghistorian:
+  resources:
+    requests:
+      memory: "256Mi"
+      cpu: 100m
+    limits:
+      memory: "512Mi"
+
+  autoscaling:
+    enabled: true
+    minReplicas: 2
+    maxReplicas: 2
+    targetCPUUtilizationPercentage: 60
+    targetMemoryUtilizationPercentage: 70
+
+  mongodb:
+    architecture: replicaset
+    replicaCount: 1
+    resources:
+      requests:
+        cpu: 150m
+        memory: 512Mi
+      limits:
+        memory: 1024Mi
+    persistence:
+      size: 1Gi
+
+  dataRetention:
+    resources:
+      requests:
+        memory: "256Mi"
+        cpu: 100m
+      limits:
+        memory: "512Mi"
+
+    autoscaling:
+      enabled: true
+      minReplicas: 2
+      maxReplicas: 2
+      targetCPUUtilizationPercentage: 60
+      targetMemoryUtilizationPercentage: 70
+
+argoworkflows:
+  argo-workflows:
+    server:
+      replicas: 1
+
+feedservice:
+  resources:
+    requests:
+      memory: "256Mi"
+      cpu: 100m
+    limits:
+      memory: "512Mi"
+
+  autoscaling:
+    enabled: true
+    minReplicas: 2
+    maxReplicas: 2
+    targetCPUUtilizationPercentage: 60
+    targetMemoryUtilizationPercentage: 70
+
+  mongodb:
+    architecture: replicaset
+    replicaCount: 1
+    resources:
+      requests:
+        cpu: 150m
+        memory: 512Mi
+      limits:
+        memory: 1024Mi
+    persistence:
+      size: 1Gi
+
+alarmservice:
+  resources:
+    requests:
+      memory: "256Mi"
+      cpu: 100m
+    limits:
+      memory: "512Mi"
+
+  autoscaling:
+    enabled: true
+    minReplicas: 2
+    maxReplicas: 2
+    targetCPUUtilizationPercentage: 60
+    targetMemoryUtilizationPercentage: 70
+
+systemsstate:
+  resources:
+    requests:
+      memory: "256Mi"
+      cpu: 100m
+    limits:
+      memory: "512Mi"
+
+  autoscaling:
+    enabled: true
+    minReplicas: 2
+    maxReplicas: 2
+    targetCPUUtilizationPercentage: 60
+    targetMemoryUtilizationPercentage: 70
+
+workorder:
+  resources:
+    requests:
+      memory: "256Mi"
+      cpu: 100m
+    limits:
+      memory: "512Mi"
+
+  autoscaling:
+    enabled: true
+    minReplicas: 2
+    maxReplicas: 2
+    targetCPUUtilizationPercentage: 60
+    targetMemoryUtilizationPercentage: 70
+
+  mongodb:
+    architecture: replicaset
+    replicaCount: 1
+    resources:
+      requests:
+        cpu: 150m
+        memory: 512Mi
+      limits:
+        memory: 1024Mi
+    persistence:
+      size: 1Gi

--- a/getting-started/templates/pilot-sizing.yaml
+++ b/getting-started/templates/pilot-sizing.yaml
@@ -10,6 +10,10 @@
 # 4 nodes - 8 CPU, 32 GB memory - General node pool
 # 2 nodes - 8 CPU, 32 GB memory - Dedicated for Dremio
 #
+# Pilot deployments use managed MongoDB Atlas or MongoDB Enterprise.
+# As such, the MongoDB resources are not specified in this file.
+# Use the MongoDB tools to size or autoscale the database.
+#
 # For production deployments, the defaults in the SystemLink helm
 # charts should be used, or similar overrides in this file could be
 # specified to further increase the availablility and performance

--- a/getting-started/templates/pilot-sizing.yaml
+++ b/getting-started/templates/pilot-sizing.yaml
@@ -10,6 +10,11 @@
 # 4 nodes - 8 CPU, 32 GB memory - General node pool
 # 2 nodes - 8 CPU, 32 GB memory - Dedicated for Dremio
 #
+# For production deployments, the defaults in the SystemLink helm
+# charts should be used, or similar overrides in this file could be
+# specified to further increase the availablility and performance
+# of specific workloads.
+#
 # This is a YAML-formatted file.
 
 alarmservice:

--- a/getting-started/templates/pilot-sizing.yaml
+++ b/getting-started/templates/pilot-sizing.yaml
@@ -2,115 +2,13 @@
 # This is a YAML-formatted file.
 # Declare override values for variables.
 
-rabbitmq:
-  resources:
-    requests:
-      cpu: "100m"
-      memory: "256Mi"
-    limits:
-      memory: "512Mi"
-
-minio:
-  persistence:
-    size: 1Gi
-  provisioning:
-    enabled: true
-    buckets:
-      - name: "systemlink-file-ingestion"
-        region: "us-east-1"
-        versioning: false
-        withLock: false
-      - name: "systemlink-dataframe"
-        region: "us-east-1"
-        versioning: false
-        withLock: false
+alarmservice:
   resources:
     requests:
       memory: "256Mi"
-      cpu: "50m"
-    limits:
-      memory: "512Mi"
-
-webserver:
-  resources:
-    requests:
-      memory: "128Mi"
-      cpu: "50m"
-    limits:
-      memory: "256Mi"
-
-  autoscaling:
-    minReplicas: 2
-    maxReplicas: 2
-    targetCPUUtilizationPercentage: 80
-    targetMemoryUtilizationPercentage: 90
-
-  redis-cluster:
-    cluster:
-      nodes: 3
-      replicas: 0
-    redis:
-      resources:
-        requests:
-          cpu: 50m
-        limits:
-
-sessionmanager:
-  resources:
-    requests:
-      memory: "64Mi"
-      cpu: "50m"
-    limits:
-      memory: "128Mi"
-
-  autoscaling:
-    minReplicas: 2
-    maxReplicas: 2
-    targetCPUUtilizationPercentage: 80
-    targetMemoryUtilizationPercentage: 90
-
-testmonitorservice:
-  resources:
-    requests:
-      memory: "256Mi"
-      cpu: "100m"
-    limits:
-      memory: "512Mi"
-
-  autoscaling:
-    minReplicas: 2
-    maxReplicas: 2
-    targetCPUUtilizationPercentage: 80
-    targetMemoryUtilizationPercentage: 90
-
-dashboardhost:
-  autoscaling:
-    minReplicas: 2
-    maxReplicas: 2
-    targetCPUUtilizationPercentage: 80
-    targetMemoryUtilizationPercentage: 90
-
-  grafana:
-    autoscaling:
-      minReplicas: 2
-      maxReplicas: 2
-      metrics:
-      - type: Resource
-        resource:
-          name: cpu
-          targetAverageUtilization: 80
-      - type: Resource
-        resource:
-          name: memory
-          targetAverageUtilization: 90
-
-dataframeservice:
-  resources:
-    requests:
-      memory: 512Mi
       cpu: 100m
     limits:
-      memory: 512Mi
+      memory: "512Mi"
 
   autoscaling:
     enabled: true
@@ -119,365 +17,10 @@ dataframeservice:
     targetCPUUtilizationPercentage: 60
     targetMemoryUtilizationPercentage: 70
 
-  mongodb:
-    architecture: replicaset
-    replicaCount: 1
-    resources:
-      requests:
-        cpu: "150m"
-        memory: "256Mi"
-      limits:
-        memory: "256Mi"
-
-saltmaster:
-  replicaCount: 1
-  resources:
-    requests:
-      memory: 256Mi
-      cpu: 150m
-    limits:
-      memory: 512Mi
-
-fileingestion:
-  resources:
-    requests:
-      memory: "128Mi"
-      cpu: "50m"
-    limits:
-      memory: "256Mi"
-
-  autoscaling:
-    minReplicas: 2
-    maxReplicas: 2
-    targetCPUUtilizationPercentage: 80
-    targetMemoryUtilizationPercentage: 90
-
-  mongodb:
-    architecture: replicaset
-    replicaCount: 1
-    resources:
-      requests:
-        cpu: 150m
-        memory: 256Mi
-      limits:
-        memory: 1024Mi
-    persistence:
-      size: 1Gi
-
-
-nbexecservice:
-  resources:
-    requests:
-      memory: "256Mi"
-      cpu: "100m"
-    limits:
-      memory: "512Mi"
-
-  autoscaling:
-    minReplicas: 2
-    maxReplicas: 2
-    targetCPUUtilizationPercentage: 80
-    targetMemoryUtilizationPercentage: 90
-
-  mongodb:
-    architecture: replicaset
-    replicaCount: 1
-    resources:
-      requests:
-        cpu: 150m
-        memory: 256Mi
-      limits:
-        memory: 1024Mi
-    persistence:
-      size: 1Gi
-
-nbparsingservice:
-  resources:
-    requests:
-      memory: "256Mi"
-      cpu: "100m"
-    limits:
-      memory: "512Mi"
-
-  autoscaling:
-    minReplicas: 2
-    maxReplicas: 2
-    targetCPUUtilizationPercentage: 80
-    targetMemoryUtilizationPercentage: 90
-
-userservices:
-  resources:
-    requests:
-      memory: "64Mi"
-      cpu: "50m"
-    limits:
-      memory: "128Mi"
-
-  autoscaling:
-    minReplicas: 2
-    maxReplicas: 2
-    targetCPUUtilizationPercentage: 80
-    targetMemoryUtilizationPercentage: 90
-
-  mongodb:
-    architecture: replicaset
-    replicaCount: 1
-    resources:
-      requests:
-        cpu: 150m
-        memory: 256Mi
-      limits:
-        memory: 1024Mi
-    persistence:
-      size: 1Gi
-
-webappservices:
-  resources:
-    requests:
-      memory: "64Mi"
-      cpu: "50m"
-    limits:
-      memory: "128Mi"
-
-  autoscaling:
-    minReplicas: 2
-    maxReplicas: 2
-    targetCPUUtilizationPercentage: 80
-    targetMemoryUtilizationPercentage: 90
-
-  mongodb:
-    architecture: replicaset
-    replicaCount: 1
-    resources:
-      requests:
-        cpu: 150m
-        memory: 256Mi
-      limits:
-        memory: 1024Mi
-    persistence:
-      size: 1Gi
-
-serviceregistry:
-  resources:
-    requests:
-      memory: "256Mi"
-      cpu: "50m"
-    limits:
-      memory: "256Mi"
-
-  autoscaling:
-    minReplicas: 2
-    maxReplicas: 2
-    targetCPUUtilizationPercentage: 80
-    targetMemoryUtilizationPercentage: 90
-
-securityui:
-  resources:
-    requests:
-      memory: "10Mi"
-      cpu: "4m"
-    limits:
-      memory: "20Mi"
-
-  autoscaling:
-    minReplicas: 2
-    maxReplicas: 2
-    targetCPUUtilizationPercentage: 80
-    targetMemoryUtilizationPercentage: 90
-
-dashboardsui:
-  resources:
-    requests:
-      memory: "10Mi"
-      cpu: "4m"
-    limits:
-      memory: "20Mi"
-
-  autoscaling:
-    minReplicas: 2
-    maxReplicas: 2
-    targetCPUUtilizationPercentage: 80
-    targetMemoryUtilizationPercentage: 90
-
-filesui:
-  resources:
-    requests:
-      memory: "10Mi"
-      cpu: "4m"
-    limits:
-      memory: "20Mi"
-
-  autoscaling:
-    minReplicas: 2
-    maxReplicas: 2
-    targetCPUUtilizationPercentage: 80
-    targetMemoryUtilizationPercentage: 90
-
-landingpageui:
-  resources:
-    requests:
-      memory: "10Mi"
-      cpu: "4m"
-    limits:
-      memory: "20Mi"
-
-  autoscaling:
-    minReplicas: 2
-    maxReplicas: 2
-    targetCPUUtilizationPercentage: 80
-    targetMemoryUtilizationPercentage: 90
-
-testinsightsui:
-  resources:
-    requests:
-      memory: "10Mi"
-      cpu: "4m"
-    limits:
-      memory: "20Mi"
-
-  autoscaling:
-    minReplicas: 2
-    maxReplicas: 2
-    targetCPUUtilizationPercentage: 80
-    targetMemoryUtilizationPercentage: 90
-
-systemsui:
-  resources:
-    requests:
-      memory: "10Mi"
-      cpu: "4m"
-    limits:
-      memory: "20Mi"
-
-  autoscaling:
-    minReplicas: 2
-    maxReplicas: 2
-    targetCPUUtilizationPercentage: 80
-    targetMemoryUtilizationPercentage: 90
-
-executionsui:
-  resources:
-    requests:
-      memory: "10Mi"
-      cpu: "4m"
-    limits:
-      memory: "20Mi"
-
-  autoscaling:
-    minReplicas: 2
-    maxReplicas: 2
-    targetCPUUtilizationPercentage: 80
-    targetMemoryUtilizationPercentage: 90
-
-userdata:
-  resources:
-    requests:
-      memory: "64Mi"
-      cpu: "25m"
-    limits:
-      memory: "128Mi"
-
-  autoscaling:
-    minReplicas: 2
-    maxReplicas: 2
-    targetCPUUtilizationPercentage: 80
-    targetMemoryUtilizationPercentage: 90
-
-  mongodb:
-    architecture: replicaset
-    replicaCount: 1
-    resources:
-      requests:
-        cpu: 150m
-        memory: 256Mi
-      limits:
-        memory: 1024Mi
-    persistence:
-      size: 1Gi
-
-routinesui:
-  resources:
-    requests:
-      memory: "10Mi"
-      cpu: "4m"
-    limits:
-      memory: "20Mi"
-
-  autoscaling:
-    minReplicas: 2
-    maxReplicas: 2
-    targetCPUUtilizationPercentage: 80
-    targetMemoryUtilizationPercentage: 90
-
-routineservice:
-  resources:
-    requests:
-      memory: "128Mi"
-      cpu: "50m"
-    limits:
-      memory: "256Mi"
-
-  autoscaling:
-    minReplicas: 2
-    maxReplicas: 2
-    targetCPUUtilizationPercentage: 80
-    targetMemoryUtilizationPercentage: 90
-
-  mongodb:
-    architecture: replicaset
-    replicaCount: 1
-    resources:
-      requests:
-        cpu: 150m
-        memory: 256Mi
-      limits:
-        memory: 1024Mi
-    persistence:
-      size: 1Gi
-
-  engine:
-    replicaCount: 1
-    resources:
-      requests:
-        memory: "25Mi"
-        cpu: "4m"
-      limits:
-        memory: "50Mi"
-
-sl-jupyterhub:
-  jupyterhub:
-    hub:
-      resources:
-        requests:
-          memory: "128Mi"
-          cpu: "100m"
-        limits:
-          memory: "256Mi"
-
-systems:
-  resources:
-    requests:
-      memory: "128Mi"
-      cpu: "50m"
-    limits:
-      memory: "256Mi"
-
-  autoscaling:
-    enabled: true
-    minReplicas: 2
-    maxReplicas: 2
-
-  mongodb:
-    architecture: replicaset
-    replicaCount: 1
-    resources:
-      requests:
-        cpu: 150m
-        memory: 256Mi
-      limits:
-        memory: 1024Mi
-    persistence:
-      size: 1Gi
+argoworkflows:
+  argo-workflows:
+    server:
+      replicas: 1
 
 assetservice:
   resources:
@@ -520,33 +63,6 @@ assetui:
     targetCPUUtilizationPercentage: 80
     targetMemoryUtilizationPercentage: 90
 
-sysmgmtevent:
-  resources:
-    requests:
-      memory: "256Mi"
-      cpu: 100m
-    limits:
-      memory: "512Mi"
-
-  autoscaling:
-    enabled: true
-    minReplicas: 2
-    maxReplicas: 2
-    targetCPUUtilizationPercentage: 60
-    targetMemoryUtilizationPercentage: 70
-
-  mongodb:
-    architecture: replicaset
-    replicaCount: 1
-    resources:
-      requests:
-        cpu: 150m
-        memory: 512Mi
-      limits:
-        memory: 1024Mi
-    persistence:
-      size: 1Gi
-
 comments:
   resources:
     requests:
@@ -574,6 +90,222 @@ comments:
     persistence:
       size: 1Gi
 
+dashboardhost:
+  autoscaling:
+    minReplicas: 2
+    maxReplicas: 2
+    targetCPUUtilizationPercentage: 80
+    targetMemoryUtilizationPercentage: 90
+
+  grafana:
+    autoscaling:
+      minReplicas: 2
+      maxReplicas: 2
+      metrics:
+      - type: Resource
+        resource:
+          name: cpu
+          targetAverageUtilization: 80
+      - type: Resource
+        resource:
+          name: memory
+          targetAverageUtilization: 90
+
+dashboardsui:
+  resources:
+    requests:
+      memory: "10Mi"
+      cpu: "4m"
+    limits:
+      memory: "20Mi"
+
+  autoscaling:
+    minReplicas: 2
+    maxReplicas: 2
+    targetCPUUtilizationPercentage: 80
+    targetMemoryUtilizationPercentage: 90
+
+dataframeservice:
+  resources:
+    requests:
+      memory: 512Mi
+      cpu: 100m
+    limits:
+      memory: 512Mi
+
+  autoscaling:
+    enabled: true
+    minReplicas: 2
+    maxReplicas: 2
+    targetCPUUtilizationPercentage: 60
+    targetMemoryUtilizationPercentage: 70
+
+  mongodb:
+    architecture: replicaset
+    replicaCount: 1
+    resources:
+      requests:
+        cpu: "150m"
+        memory: "256Mi"
+      limits:
+        memory: "256Mi"
+
+executionsui:
+  resources:
+    requests:
+      memory: "10Mi"
+      cpu: "4m"
+    limits:
+      memory: "20Mi"
+
+  autoscaling:
+    minReplicas: 2
+    maxReplicas: 2
+    targetCPUUtilizationPercentage: 80
+    targetMemoryUtilizationPercentage: 90
+
+feedservice:
+  resources:
+    requests:
+      memory: "256Mi"
+      cpu: 100m
+    limits:
+      memory: "512Mi"
+
+  autoscaling:
+    enabled: true
+    minReplicas: 2
+    maxReplicas: 2
+    targetCPUUtilizationPercentage: 60
+    targetMemoryUtilizationPercentage: 70
+
+  mongodb:
+    architecture: replicaset
+    replicaCount: 1
+    resources:
+      requests:
+        cpu: 150m
+        memory: 512Mi
+      limits:
+        memory: 1024Mi
+    persistence:
+      size: 1Gi
+
+fileingestion:
+  resources:
+    requests:
+      memory: "128Mi"
+      cpu: "50m"
+    limits:
+      memory: "256Mi"
+
+  autoscaling:
+    minReplicas: 2
+    maxReplicas: 2
+    targetCPUUtilizationPercentage: 80
+    targetMemoryUtilizationPercentage: 90
+
+  mongodb:
+    architecture: replicaset
+    replicaCount: 1
+    resources:
+      requests:
+        cpu: 150m
+        memory: 256Mi
+      limits:
+        memory: 1024Mi
+    persistence:
+      size: 1Gi
+
+filesui:
+  resources:
+    requests:
+      memory: "10Mi"
+      cpu: "4m"
+    limits:
+      memory: "20Mi"
+
+  autoscaling:
+    minReplicas: 2
+    maxReplicas: 2
+    targetCPUUtilizationPercentage: 80
+    targetMemoryUtilizationPercentage: 90
+
+landingpageui:
+  resources:
+    requests:
+      memory: "10Mi"
+      cpu: "4m"
+    limits:
+      memory: "20Mi"
+
+  autoscaling:
+    minReplicas: 2
+    maxReplicas: 2
+    targetCPUUtilizationPercentage: 80
+    targetMemoryUtilizationPercentage: 90
+
+minio:
+  persistence:
+    size: 1Gi
+  provisioning:
+    enabled: true
+    buckets:
+      - name: "systemlink-file-ingestion"
+        region: "us-east-1"
+        versioning: false
+        withLock: false
+      - name: "systemlink-dataframe"
+        region: "us-east-1"
+        versioning: false
+        withLock: false
+  resources:
+    requests:
+      memory: "256Mi"
+      cpu: "50m"
+    limits:
+      memory: "512Mi"
+
+nbexecservice:
+  resources:
+    requests:
+      memory: "256Mi"
+      cpu: "100m"
+    limits:
+      memory: "512Mi"
+
+  autoscaling:
+    minReplicas: 2
+    maxReplicas: 2
+    targetCPUUtilizationPercentage: 80
+    targetMemoryUtilizationPercentage: 90
+
+  mongodb:
+    architecture: replicaset
+    replicaCount: 1
+    resources:
+      requests:
+        cpu: 150m
+        memory: 256Mi
+      limits:
+        memory: 1024Mi
+    persistence:
+      size: 1Gi
+
+nbparsingservice:
+  resources:
+    requests:
+      memory: "256Mi"
+      cpu: "100m"
+    limits:
+      memory: "512Mi"
+
+  autoscaling:
+    minReplicas: 2
+    maxReplicas: 2
+    targetCPUUtilizationPercentage: 80
+    targetMemoryUtilizationPercentage: 90
+
 notification:
   resources:
     requests:
@@ -600,6 +332,14 @@ notification:
         memory: 1024Mi
     persistence:
       size: 1Gi
+
+rabbitmq:
+  resources:
+    requests:
+      cpu: "100m"
+      memory: "256Mi"
+    limits:
+      memory: "512Mi"
 
 repository:
   resources:
@@ -675,6 +415,55 @@ routinescheduletrigger:
     persistence:
       size: 1Gi
 
+routineservice:
+  resources:
+    requests:
+      memory: "128Mi"
+      cpu: "50m"
+    limits:
+      memory: "256Mi"
+
+  autoscaling:
+    minReplicas: 2
+    maxReplicas: 2
+    targetCPUUtilizationPercentage: 80
+    targetMemoryUtilizationPercentage: 90
+
+  mongodb:
+    architecture: replicaset
+    replicaCount: 1
+    resources:
+      requests:
+        cpu: 150m
+        memory: 256Mi
+      limits:
+        memory: 1024Mi
+    persistence:
+      size: 1Gi
+
+  engine:
+    replicaCount: 1
+    resources:
+      requests:
+        memory: "25Mi"
+        cpu: "4m"
+      limits:
+        memory: "50Mi"
+
+routinesui:
+  resources:
+    requests:
+      memory: "10Mi"
+      cpu: "4m"
+    limits:
+      memory: "20Mi"
+
+  autoscaling:
+    minReplicas: 2
+    maxReplicas: 2
+    targetCPUUtilizationPercentage: 80
+    targetMemoryUtilizationPercentage: 90
+
 saltmaster:
   resources:
     requests:
@@ -701,6 +490,58 @@ saltmaster:
         memory: 1024Mi
     persistence:
       size: 1Gi
+
+securityui:
+  resources:
+    requests:
+      memory: "10Mi"
+      cpu: "4m"
+    limits:
+      memory: "20Mi"
+
+  autoscaling:
+    minReplicas: 2
+    maxReplicas: 2
+    targetCPUUtilizationPercentage: 80
+    targetMemoryUtilizationPercentage: 90
+
+serviceregistry:
+  resources:
+    requests:
+      memory: "256Mi"
+      cpu: "50m"
+    limits:
+      memory: "256Mi"
+
+  autoscaling:
+    minReplicas: 2
+    maxReplicas: 2
+    targetCPUUtilizationPercentage: 80
+    targetMemoryUtilizationPercentage: 90
+
+sessionmanager:
+  resources:
+    requests:
+      memory: "64Mi"
+      cpu: "50m"
+    limits:
+      memory: "128Mi"
+
+  autoscaling:
+    minReplicas: 2
+    maxReplicas: 2
+    targetCPUUtilizationPercentage: 80
+    targetMemoryUtilizationPercentage: 90
+
+sl-jupyterhub:
+  jupyterhub:
+    hub:
+      resources:
+        requests:
+          memory: "128Mi"
+          cpu: "100m"
+        limits:
+          memory: "256Mi"
 
 smtp:
   resources:
@@ -731,6 +572,87 @@ swaggerapi:
     maxReplicas: 2
     targetCPUUtilizationPercentage: 60
     targetMemoryUtilizationPercentage: 70
+
+sysmgmtevent:
+  resources:
+    requests:
+      memory: "256Mi"
+      cpu: 100m
+    limits:
+      memory: "512Mi"
+
+  autoscaling:
+    enabled: true
+    minReplicas: 2
+    maxReplicas: 2
+    targetCPUUtilizationPercentage: 60
+    targetMemoryUtilizationPercentage: 70
+
+  mongodb:
+    architecture: replicaset
+    replicaCount: 1
+    resources:
+      requests:
+        cpu: 150m
+        memory: 512Mi
+      limits:
+        memory: 1024Mi
+    persistence:
+      size: 1Gi
+
+systems:
+  resources:
+    requests:
+      memory: "128Mi"
+      cpu: "50m"
+    limits:
+      memory: "256Mi"
+
+  autoscaling:
+    enabled: true
+    minReplicas: 2
+    maxReplicas: 2
+
+  mongodb:
+    architecture: replicaset
+    replicaCount: 1
+    resources:
+      requests:
+        cpu: 150m
+        memory: 256Mi
+      limits:
+        memory: 1024Mi
+    persistence:
+      size: 1Gi
+
+systemsstate:
+  resources:
+    requests:
+      memory: "256Mi"
+      cpu: 100m
+    limits:
+      memory: "512Mi"
+
+  autoscaling:
+    enabled: true
+    minReplicas: 2
+    maxReplicas: 2
+    targetCPUUtilizationPercentage: 60
+    targetMemoryUtilizationPercentage: 70
+
+systemsui:
+  resources:
+    requests:
+      memory: "10Mi"
+      cpu: "4m"
+    limits:
+      memory: "20Mi"
+
+  autoscaling:
+    minReplicas: 2
+    maxReplicas: 2
+    targetCPUUtilizationPercentage: 80
+    targetMemoryUtilizationPercentage: 90
 
 tags:
   resources:
@@ -801,25 +723,47 @@ taghistorian:
       targetCPUUtilizationPercentage: 60
       targetMemoryUtilizationPercentage: 70
 
-argoworkflows:
-  argo-workflows:
-    server:
-      replicas: 1
+testinsightsui:
+  resources:
+    requests:
+      memory: "10Mi"
+      cpu: "4m"
+    limits:
+      memory: "20Mi"
 
-feedservice:
+  autoscaling:
+    minReplicas: 2
+    maxReplicas: 2
+    targetCPUUtilizationPercentage: 80
+    targetMemoryUtilizationPercentage: 90
+
+testmonitorservice:
   resources:
     requests:
       memory: "256Mi"
-      cpu: 100m
+      cpu: "100m"
     limits:
       memory: "512Mi"
 
   autoscaling:
-    enabled: true
     minReplicas: 2
     maxReplicas: 2
-    targetCPUUtilizationPercentage: 60
-    targetMemoryUtilizationPercentage: 70
+    targetCPUUtilizationPercentage: 80
+    targetMemoryUtilizationPercentage: 90
+
+userdata:
+  resources:
+    requests:
+      memory: "64Mi"
+      cpu: "25m"
+    limits:
+      memory: "128Mi"
+
+  autoscaling:
+    minReplicas: 2
+    maxReplicas: 2
+    targetCPUUtilizationPercentage: 80
+    targetMemoryUtilizationPercentage: 90
 
   mongodb:
     architecture: replicaset
@@ -827,41 +771,87 @@ feedservice:
     resources:
       requests:
         cpu: 150m
-        memory: 512Mi
+        memory: 256Mi
       limits:
         memory: 1024Mi
     persistence:
       size: 1Gi
 
-alarmservice:
+userservices:
   resources:
     requests:
-      memory: "256Mi"
-      cpu: 100m
+      memory: "64Mi"
+      cpu: "50m"
     limits:
-      memory: "512Mi"
+      memory: "128Mi"
 
   autoscaling:
-    enabled: true
     minReplicas: 2
     maxReplicas: 2
-    targetCPUUtilizationPercentage: 60
-    targetMemoryUtilizationPercentage: 70
+    targetCPUUtilizationPercentage: 80
+    targetMemoryUtilizationPercentage: 90
 
-systemsstate:
+  mongodb:
+    architecture: replicaset
+    replicaCount: 1
+    resources:
+      requests:
+        cpu: 150m
+        memory: 256Mi
+      limits:
+        memory: 1024Mi
+    persistence:
+      size: 1Gi
+
+webappservices:
   resources:
     requests:
-      memory: "256Mi"
-      cpu: 100m
+      memory: "64Mi"
+      cpu: "50m"
     limits:
-      memory: "512Mi"
+      memory: "128Mi"
 
   autoscaling:
-    enabled: true
     minReplicas: 2
     maxReplicas: 2
-    targetCPUUtilizationPercentage: 60
-    targetMemoryUtilizationPercentage: 70
+    targetCPUUtilizationPercentage: 80
+    targetMemoryUtilizationPercentage: 90
+
+  mongodb:
+    architecture: replicaset
+    replicaCount: 1
+    resources:
+      requests:
+        cpu: 150m
+        memory: 256Mi
+      limits:
+        memory: 1024Mi
+    persistence:
+      size: 1Gi
+
+webserver:
+  resources:
+    requests:
+      memory: "128Mi"
+      cpu: "50m"
+    limits:
+      memory: "256Mi"
+
+  autoscaling:
+    minReplicas: 2
+    maxReplicas: 2
+    targetCPUUtilizationPercentage: 80
+    targetMemoryUtilizationPercentage: 90
+
+  redis-cluster:
+    cluster:
+      nodes: 3
+      replicas: 0
+    redis:
+      resources:
+        requests:
+          cpu: 50m
+        limits:
 
 workorder:
   resources:


### PR DESCRIPTION
Provide a sizing file that specifies resources and replicas for a SystemLink Enterprise pilot deployment.

- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/install-systemlink-enterprise/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

This pull request adds a new template yaml file that specifies the resources and replica counts for a pilot-sized deployment.

### Why should this Pull Request be merged?

Provide customers with a template to speed up initial deployment of pilot environments.

### What testing has been done?

Deployed the solution manually and verified that the services start correctly and are capable of handling a reasonable load for a pilot.
