### PR TITLE
Add node selector for nbexecservice argo workflows

### DIFF
--- a/getting-started/templates/node-selectors.yaml
+++ b/getting-started/templates/node-selectors.yaml
@@ -157,6 +157,10 @@ nbexecservice:
   nodeSelector: *servicesNodeSelector
   tolerations: *servicesTolerations
   affinity: *servicesAffinity
+  argo:
+    workflow:
+      nodeSelector: *notebookExecutionNodeSelector
+      tolerations: *notebookExecutionTolerations
 
 nbparsingservice:
   nodeSelector: *servicesNodeSelector


### PR DESCRIPTION
Ensure notebook execution pods are scheduled on the labeled node.

- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/install-systemlink-enterprise/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Corrects a missing node selector for notebook executions using argo workflows.

### Why should this Pull Request be merged?

This ensures that notebook workloads are scheduled on the correctly labeled node.

### What testing has been done?

Visual inspection of helm charts.
