### PR TITLE
Add pilot sizing for Dremio

### DIFF
--- a/getting-started/templates/pilot-sizing.yaml
+++ b/getting-started/templates/pilot-sizing.yaml
@@ -134,6 +134,19 @@ dataframeservice:
     maxReplicas: 2
     targetCPUUtilizationPercentage: 60
     targetMemoryUtilizationPercentage: 70
+  
+  sldremio:
+    coordinator:
+      cpu: 2
+      memory: 16384
+      volumeSize: "50Gi"
+    executor:
+      count: 1
+      cpu: 1
+      memory: 16384
+      volumeSize: "10Gi"
+    zookeeper:
+      count: 1
 
 executionsui:
   resources:

--- a/getting-started/templates/pilot-sizing.yaml
+++ b/getting-started/templates/pilot-sizing.yaml
@@ -138,12 +138,12 @@ dataframeservice:
   sldremio:
     coordinator:
       cpu: 4
-      memory: 32768
+      memory: 31000
       volumeSize: "100Gi"
     executor:
       count: 1
       cpu: 4
-      memory: 32768
+      memory: 31000
       volumeSize: "50Gi"
     zookeeper:
       count: 1

--- a/getting-started/templates/pilot-sizing.yaml
+++ b/getting-started/templates/pilot-sizing.yaml
@@ -147,6 +147,22 @@ dataframeservice:
       volumeSize: "50Gi"
     zookeeper:
       count: 1
+  # The above is the recommended configuration for pilot deployments.
+  # For deployments where the DataFrame Service will not be used, the following
+  # configuration is the bare minimum for the Dremio pods to start up:
+  # sldremio:
+  #   coordinator:
+  #     cpu: 1
+  #     memory: 4096
+  #     volumeSize: "10Gi"
+  #   executor:
+  #     count: 1
+  #     cpu: 1
+  #     memory: 4096
+  #     volumeSize: "10Gi"
+  #   zookeeper:
+  #     count: 1
+
 
 executionsui:
   resources:

--- a/getting-started/templates/pilot-sizing.yaml
+++ b/getting-started/templates/pilot-sizing.yaml
@@ -137,14 +137,14 @@ dataframeservice:
   
   sldremio:
     coordinator:
-      cpu: 2
-      memory: 16384
-      volumeSize: "50Gi"
+      cpu: 4
+      memory: 32768
+      volumeSize: "100Gi"
     executor:
       count: 1
-      cpu: 1
-      memory: 16384
-      volumeSize: "10Gi"
+      cpu: 4
+      memory: 32768
+      volumeSize: "50Gi"
     zookeeper:
       count: 1
 


### PR DESCRIPTION
- [X] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/install-systemlink-enterprise/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

`pilot-sizing.yaml` [suggests](https://github.com/ni/install-systemlink-enterprise/blob/3d254e0c64feca5f5855d2898f2bbb5265532885/getting-started/templates/pilot-sizing.yaml#L11) we should have a two-node deployment for Dremio, with each node having 8 cores and 32 GB of RAM. This PR configures Dremio to fit into such a node pool.

### Why should this Pull Request be merged?

`pilot-values.yaml` is missing the configuration needed for Dremio to run in the suggested node pool for pilots.

### What testing has been done?

We've previously verified that Dremio can run with this configuration, though it should not be used at scale.