### PR TITLE
Add missing details about argo workflows instance id

### DIFF
--- a/getting-started/templates/systemlink-admin-values.yaml
+++ b/getting-started/templates/systemlink-admin-values.yaml
@@ -16,3 +16,9 @@ global:
   # <ATTENTION> - Set to false if you do not want to manage secrets as part of the Helm installation.
   ##
   deploySecrets: true
+
+## Uncomment and adjust installation of Argo Workflows CRDs. Disable the installation of Argo Workflows CRDs
+## when you already have them installed in your cluster as part of other Argo Workflows deployment.
+# argoworkflowscrds:
+#   crds:
+#     install: true

--- a/getting-started/templates/systemlink-admin-values.yaml
+++ b/getting-started/templates/systemlink-admin-values.yaml
@@ -17,8 +17,9 @@ global:
   ##
   deploySecrets: true
 
-## Uncomment and adjust installation of Argo Workflows CRDs. Disable the installation of Argo Workflows CRDs
-## when you already have them installed in your cluster as part of other Argo Workflows deployment.
+## Uncomment to disable the installation of Argo Workflows CRDs. Use this option if Argo Workflows
+## CRDs are already installed in your cluster as part of another Argo Workflows deployment
 # argoworkflowscrds:
 #   crds:
-#     install: true
+#     install: false
+

--- a/getting-started/templates/systemlink-values.yaml
+++ b/getting-started/templates/systemlink-values.yaml
@@ -1011,6 +1011,11 @@ argoworkflows:
       ## Maximum number of workflows that can run in parallel.
       ##
       parallelism: &workflowParallelism 300
+      ## Uncomment to specify instanceID for Argo Workflows. This is needed to avoid conlicts with already existing
+      ## Argo Workflows deployments in the cluster.
+      # instanceID:
+      #   enabled: true
+      #   explicitID: sl-notebook-execution-0
     executor:
       image:
         registry: *imageRegistryRef

--- a/getting-started/templates/systemlink-values.yaml
+++ b/getting-started/templates/systemlink-values.yaml
@@ -1011,7 +1011,7 @@ argoworkflows:
       ## Maximum number of workflows that can run in parallel.
       ##
       parallelism: &workflowParallelism 300
-      ## Uncomment to specify instanceID for Argo Workflows. This is needed to avoid conlicts with already existing
+      ## Uncomment to specify instanceID for Argo Workflows. This is needed to avoid conflicts with already existing
       ## Argo Workflows deployments in the cluster.
       # instanceID:
       #   enabled: true


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/install-systemlink-enterprise/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Add details about argo workflows instance id and crds installation, needed when there is an already installed argo-workflows in the cluster

### Why should this Pull Request be merged?

These are already defined in public doc: https://www.ni.com/docs/en-US/bundle/systemlink-enterprise/page/configuring-the-notebook-exectution-service.html

My understanding is that the public doc should reference configuration in the helm values, so it's better to have the configuration commented there.

### What testing has been done?

N/A, just placing what is already documented.
