### PR TITLE
DFS: Update pilot config for the compaction feature

### DIFF
--- a/getting-started/templates/pilot-sizing.yaml
+++ b/getting-started/templates/pilot-sizing.yaml
@@ -152,9 +152,6 @@ dataframeservice:
       cpu: 4
       memory: 31000
       volumeSize: "50Gi"
-      engines:
-        - default
-        - iceberg
       engineOverride:
         iceberg:
           count: 2

--- a/getting-started/templates/pilot-sizing.yaml
+++ b/getting-started/templates/pilot-sizing.yaml
@@ -8,7 +8,7 @@
 # kubernetes cluster nodes. The cluster is intended to be deployed
 # with the following node topology:
 # 4 nodes - 8 CPU, 32 GB memory - General node pool
-# 2 nodes - 8 CPU, 32 GB memory - Dedicated for Dremio
+# 3 nodes - 8 CPU, 32 GB memory - Dedicated for Dremio
 #
 # Pilot deployments use managed MongoDB Atlas or MongoDB Enterprise.
 # As such, the MongoDB resources are not specified in this file.
@@ -134,6 +134,13 @@ dataframeservice:
     maxReplicas: 2
     targetCPUUtilizationPercentage: 60
     targetMemoryUtilizationPercentage: 70
+
+  queryEngine:
+    workloadManagement:
+      writeQueue:
+        concurrencyLimit: 5
+      optimizeQueue:
+        concurrencyLimit: 4
   
   sldremio:
     coordinator:
@@ -145,6 +152,16 @@ dataframeservice:
       cpu: 4
       memory: 31000
       volumeSize: "50Gi"
+      engines:
+        - default
+        - iceberg
+      engineOverride:
+        iceberg:
+          count: 2
+          cpu: 4
+          memory: 16384
+          heapMemoryOverride: 10000
+          directMemoryOverride: 5000
     zookeeper:
       count: 1
   # The above is the recommended configuration for pilot deployments.

--- a/getting-started/templates/systemlink-values.yaml
+++ b/getting-started/templates/systemlink-values.yaml
@@ -761,6 +761,26 @@ dataframeservice:
     ##
     region: "us-east-1"
 
+  ## Configure the Dremio query engine
+  ##
+  # queryEngine:
+    ## Configuration for Dremio Workload Management. This is used
+    ## to isolate operations related to data ingestion from queries. For more
+    ## information, see https://docs.dremio.com/current/admin/workloads/workload-management/
+    # workloadManagement:
+      ## COPY INTO jobs are targeted to this queue. Increase the concurrency limit
+      ## to make newly ingested data available for query faster. This may require
+      ## adding more resources to the engine the query is targeting.
+      # writeQueue:
+        # concurrencyLimit: 5
+        # engineName: "iceberg"
+      ## Compaction jobs are targeted to this queue. Increase the concurrency limit
+      ## to make newly ingested data available for query faster. This may require
+      ## adding more resources to the engine the query is targeting.
+      # optimizeQueue:
+        # concurrencyLimit: 4
+        # engineName: "iceberg"
+
   ## Configure Dremio access
   ##
   sldremio:
@@ -774,12 +794,22 @@ dataframeservice:
     # coordinator:
     #   cpu: 15
     #   memory: 122800
-    #   volumeSize: 128Gi
+    #   volumeSize: 256Gi
     # executor:
-    #   count: 4
+    #   count: 3
     #   cpu: 15
-    #   memory: 122800
-    #   volumeSize: 128Gi
+    #   memory: 73728
+    #   volumeSize: 256Gi
+    # engines:
+    #   - default
+    #   - iceberg
+    # engineOverride:
+    #   iceberg:
+    #     count: 4
+    #     cpu: 9
+    #     memory: 32768
+    #     heapMemoryOverride: 20000
+    #     directMemoryOverride: 10000
     ## CPU and memory allocated to each zookeeper pod, expressed in CPU cores and MB respectively.
     ## Count should correspond with the number of nodes that received the "high.mem" label.
     # zookeeper:


### PR DESCRIPTION
- [X] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/install-systemlink-enterprise/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Adds a modest Iceberg engine for pilot deployments.

### Why should this Pull Request be merged?

To isolate reads from writes at runtime, and to provide Dremio with enough resources to compact and add data to tables of modest size, we need to provision an Iceberg execution engine. We also need to adjust the number of concurrent compaction and ingestion jobs we ask Dremio to handle so that we don't overwhelm the modest Iceberg engine we're deploying for pilots.

We shouldn't merge this until we're ready to enable compaction by default.

### What testing has been done?

I verified this Iceberg engine can handle a burst of 30 concurrent reference table writers. That is, 30 threads writing 200k rows to a different table with 200 FLOAT64 columns in 4k batches. All data was compacted and made available for query within 10 minutes of ingestion starting.
