### PR TITLE
Remove MinIO from the SLE install and add help for manual installs

### DIFF
--- a/getting-started/templates/systemlink-values.yaml
+++ b/getting-started/templates/systemlink-values.yaml
@@ -124,6 +124,30 @@ global:
   ##
   deployApiHostCertificateToSystems: false
 
+## The following values are typically shared across multiple configurations. The values
+## here are not used directly as configuration but provide a convenient way to share
+## common configuration throughout this file. Individual references to these values can
+## be overridden with custom values if required.
+##
+## Hostname of an external S3 provider.
+# <ATTENTION> To connect to an external S3 provider, set s3Host s3Scheme, s3Port and s3Region.
+##
+s3Host: &s3Host "s3.amazonaws.com"
+## Service name of an on-cluster S3 provider.
+# <ATTENTION> To connect to an S3 provider within the same cluster, set s3ServiceName, s3Scheme, s3Port and s3Region,
+#             and set s3Host to an empty string.
+##
+s3ServiceName: &s3ServiceName ""
+## Schema used to access the configured S3 provider ("http" or "https")
+##
+s3Scheme: &s3Scheme "https"
+## Port number of the S3 provider
+##
+s3Port: &s3Port 443
+## Region where S3 storage is located
+##
+s3Region: &s3Region "us-east-1"
+
 ## Core configuration for the RabbitMQ message broker
 ##
 rabbitmq:
@@ -243,65 +267,6 @@ database:
   ## Name of the ConfigMap used to deploy the certificate.
   ##
   postgresCertificateConfigMapName: &postgresCertificateConfigMap "postgres-tls-certificate"
-
-## MinIO block storage configuration.
-##
-minio:
-  ## Set to false to disable deployment of the minio service. If minio is not deployed, an alternative S3 provider
-  ## must be configured. Refer to the fileingestion.s3, nbexecservice.argo.s3, and dataframeservice.s3 sections
-  ## to configure an S3 provider.
-  # <ATTENTION> - Set to false if not using minio for S3 storage.
-  ##
-  enabled: true
-
-  ## String to partially override common.names.fullname template (will maintain the release name)
-  ##
-  nameOverride: &minioServiceName "minio"
-
-  ## Setup user credentials.
-  ##
-  auth:
-    existingSecret: "minio-credentials"
-
-  ## Port configuration
-  containerPorts:
-    ##  MinIO container port to open for MinIO API
-    ##
-    api: &minioPort 9000
-
-  ## Storage configuration.
-  persistence:
-    ## PVC Storage Request for MinIO data volume
-    # <ATTENTION> - Adjust this size to match the needs of your application. MinIO will be used to store uploaded files and data frames.
-    ##
-    size: 50Gi
-
-  ## Configure the ingress resource that allows you to access the MinIO UI.
-  ## ref: https://kubernetes.io/docs/user-guide/ingress/
-  ##
-  ingress:
-    ## Enable ingress controller resource.
-    # <ATTENTION> - Enable this toggle and configure a host name to allow access to the MinIO UI
-    ##
-    enabled: false
-    ## @param ingress.hostname Default host for the ingress resource.
-    ##
-    hostname: "systemlink-minio.example.com"
-
-  ## Configure the ingress resource that allows you to access the MinIO API.
-  ## ref: https://kubernetes.io/docs/user-guide/ingress/
-  ##
-  apiIngress:
-    ## Enable ingress controller resource.
-    # <ATTENTION> - Enable this toggle and configure a host name to allow access to the MinIO API
-    ##
-    enabled: false
-    ## Default host for the ingress resource.
-    ##
-    hostname: "systemlink-minio-api.example.com"
-  ## Comma, semi-colon or space separated list of buckets to create at initialization (only in standalone mode).
-  ##
-  defaultBuckets: "systemlink-file-ingestion;systemlink-dataframe;systemlink-notebook-execution;systemlink-feeds"
 
 ## Configuration for test result storage.
 ##
@@ -729,37 +694,35 @@ dataframeservice:
   ## Accepts units in "MiB" (Mebibytes, 1024 KiB) or in "MB" (Megabytes, 1000 KB)
   requestBodySizeLimit: 256MiB
 
-  ## Configure S3/MinIO access.
+  ## Configure S3 access.
   ##
   s3:
     auth:
-      ## Name of the secret containing the S3 or MinIO login credentials
+      ## Name of the secret containing the S3 login credentials
       ##
       secretName: "nidataframe-s3-credentials"
-    ## The name of the S3 or MinIO bucket that the service should connect to.
+    ## The name of the S3 bucket that the service should connect to.
     ##
     bucket: &dataframeBucket "systemlink-dataframe"
     ## This should just be the name of the scheme, without the trailing ://.
     ##
-    schemeName: "http"
+    schemeName: *s3Scheme
     ## Set this value to connect to an external S3 instance.
-    # <ATTENTION> To connect to an external S3 bucket, set the host here as well as the schemeName and port.
     ##
-    host: ""
+    host: *s3Host
     ## Set this value to connect to an S3 instance which is internal to the cluster. Ignored if host is set.
     ##
-    service: *minioServiceName
+    service: *s3ServiceName
     ## S3 port number.
-    # <ATTENTION> This must be overridden if not using the SLE MinIO instance.
     ##
-    port: *minioPort
+    port: *s3Port
     ## Maximum number of concurrent connections to S3 per replica.
     ##
     maximumConnections: 32
     ## S3 Region
     # <ATTENTION> This must be set to the region of the S3 instance.
     ##
-    region: "us-east-1"
+    region: *s3Region
 
   ## Configure Dremio access
   ##
@@ -807,28 +770,27 @@ dataframeservice:
         path: "/dremio/distStorage"
         authentication: "accessKeySecret"
         # extraProperties are only necessary if not using Amazon S3
-        # <ATTENTION>: If using Amazon S3, comment out extraProperties. If using MinIO or an equivalent, set fs.s3a.endpoint
-        # to the FQDN of MinIO or the equivalent service.
-        extraProperties: |
-          <property>
-            <name>fs.s3a.endpoint</name>
-            <value><ATTENTION> - set to the FQDN of the S3 endpoint, including the port, but without an HTTP or HTTPS prefix. Example: {svc-name}.{namespace}.svc.cluster.local:9000</value>
-          </property>
-          <property>
-            <name>fs.s3a.path.style.access</name>
-            <description>Value has to be set to true.</description>
-            <value>true</value>
-          </property>
-          <property>
-            <name>dremio.s3.compat</name>
-            <description>Value has to be set to true.</description>
-            <value>true</value>
-          </property>
-          <property>
-            <name>fs.s3a.connection.ssl.enabled</name>
-            <description>Value can either be true or false, set to true to use SSL with a secure Minio server.</description>
-            <value>false</value>
-          </property>
+        # <ATTENTION>: If using MinIO or an equivalent, set fs.s3a.endpoint to the FQDN of MinIO or the equivalent service.
+        # extraProperties: |
+        #   <property>
+        #     <name>fs.s3a.endpoint</name>
+        #     <value><ATTENTION> - set to the FQDN of the S3 endpoint, including the port, but without an HTTP or HTTPS prefix. Example: {svc-name}.{namespace}.svc.cluster.local:9000</value>
+        #   </property>
+        #   <property>
+        #     <name>fs.s3a.path.style.access</name>
+        #     <description>Value has to be set to true.</description>
+        #     <value>true</value>
+        #   </property>
+        #   <property>
+        #     <name>dremio.s3.compat</name>
+        #     <description>Value has to be set to true.</description>
+        #     <value>true</value>
+        #   </property>
+        #   <property>
+        #     <name>fs.s3a.connection.ssl.enabled</name>
+        #     <description>Value can either be true or false, set to true to use SSL with a secure Minio server.</description>
+        #     <value>false</value>
+        #   </property>
 
 ## Salt configuration.
 ##
@@ -843,33 +805,30 @@ saltmaster:
 ## Feed configuration.
 ##
 feedservice:
-  ## Configure S3/MinIO access.
+  ## Configure S3 access.
   ##
   s3:
     ## Secret name for S3 credentials.
     ##
     secretName: "feeds-s3-credentials"
-    ## The name of the S3 or MinIO bucket that the service should connect to.
+    ## The name of the S3 bucket that the service should connect to.
     ##
     bucket: "systemlink-feeds"
     ## S3 connection scheme.
     ##
-    scheme: "http://"
+    scheme: *s3Scheme
     ## Set this value to connect to an external S3 instance.
-    # <ATTENTION> To connect to an external S3 bucket, set the host here as well as the scheme and port.
     ##
-    host: ""
+    host: *s3Host
     ## Set this value to connect to an S3 instance which is internal to the cluster. Ignored if host is set.
     ##
-    service: *minioServiceName
+    service: *s3ServiceName
     ## S3 Port
-    # <ATTENTION> This must be overridden if not using the SLE MinIO instance.
     ##
-    port: *minioPort
+    port: *s3Port
     ## S3 Region
-    # <ATTENTION> This must be set to the region of the S3 instance.
     ##
-    region: "us-east-1"
+    region: *s3Region
   ## Proxy configuration to be used when the service needs to go through a proxy to have access to external services like ni.com.
   httpProxy:
     ## @param httpProxy.address Address of the HTTP proxy in the $host:$port format. Example: "1.1.1.1:2222"
@@ -899,13 +858,13 @@ fileingestion:
       nginx.ingress.kubernetes.io/proxy-request-buffering: "off"
       nginx.ingress.kubernetes.io/proxy-buffering: "off"
 
-  ## Configure S3/MinIO access.
+  ## Configure S3 access.
   ##
   s3:
     ## Secret name for S3 credentials.
     ##
     secretName: "fileingestion-s3-credentials"
-    ## The name of the S3 or MinIO bucket that the service should connect to.
+    ## The name of the S3 bucket that the service should connect to.
     ##
     bucket: "systemlink-file-ingestion"
     ## Set this to true to limit each user to a maximum of 1Gb of file storage.
@@ -913,22 +872,19 @@ fileingestion:
     storageLimitsEnabled: false
     ## S3 connection scheme.
     ##
-    scheme: "http://"
+    scheme: *s3Scheme
     ## Set this value to connect to an external S3 instance.
-    # <ATTENTION> To connect to an external S3 bucket, set the host here as well as the scheme and port.
     ##
-    host: ""
+    host: *s3Host
     ## Set this value to connect to an S3 instance which is internal to the cluster. Ignored if host is set.
     ##
-    service: *minioServiceName
+    service: *s3ServiceName
     ## S3 Port
-    # <ATTENTION> This must be overridden if not using the SLE MinIO instance.
     ##
-    port: *minioPort
+    port: *s3Port
     ## S3 Region
-    # <ATTENTION> This must be set to the region of the S3 instance.
     ##
-    region: "us-east-1"
+    region: *s3Region
    ## Configure rate limiting. Limits are enforced per-user.  Each replica of the file ingestion service
    ## applies its own per-user limit. With load-balancing, the effective rate will be higher than the
    ## individual rates configured here.
@@ -1027,103 +983,67 @@ argoworkflows:
 ##
 nbexecservice:
   maxNumberOfWorkflowsToSchedule: *workflowParallelism
-  ## Configure S3/MinIO access.
+  ## Configure S3 access.
   ##
   s3:
     ## Secret name for S3 credentials.
     ##
     secretName: "nbexecservice-s3-credentials"
-    ## The name of the S3 or MinIO bucket that the service should connect to.
+    ## The name of the S3 bucket that the service should connect to.
     ##
     bucket: "systemlink-executions"
     ## S3 connection scheme.
     ##
-    scheme: "http://"
+    scheme: *s3Scheme
     ## Set this value to connect to an external S3 instance.
-    # <ATTENTION> To connect to an external S3 bucket, set the host here as well as the scheme and port.
     ##
-    host: ""
+    host: *s3Host
     ## Set this value to connect to an S3 instance which is internal to the cluster. Ignored if host is set.
     ##
-    service: *minioServiceName
+    service: *s3ServiceName
     ## S3 Port
-    # <ATTENTION> This must be overridden if not using the SLE MinIO instance.
-    port: *minioPort
+    port: *s3Port
     ## S3 Region
-    # <ATTENTION> This must be set to the region of the S3 instance.
     ##
-    region: "us-east-1"
-  argo:
-    ## Configure S3/MinIO access.
-    ##
-    artifactRepository:
-      s3:
-        ## The name of the S3 or MinIO bucket that the service should connect to.
-        ##
-        bucket: "systemlink-notebook-execution"
-        ## Set this value to connect to an external S3 instance.
-        # <ATTENTION> To connect to an external S3 bucket, set the host here as well as the insecure and port.
-        ##
-        host: ""
-        ## Set this value to connect to an S3 instance which is internal to the cluster. Ignored if host is set.
-        ##
-        service: *minioServiceName
-        ## S3 Port
-        # <ATTENTION> This must be overridden if not using the SLE MinIO instance.
-        ##
-        port: *minioPort
-        ## Set this value to true for an http (insecure) connection, or false for an https (secure) connection.
-        ##
-        insecure: true
-        ## Secret PATH containing the credentials.
-        accessKeySecret:
-          name: "notebookexecution-s3-credentials"
-          key: "username"
-        secretKeySecret:
-          name: "notebookexecution-s3-credentials"
-          key: "password"
-        ## Secret PATH containing trusted certificate that should be used for s3 communication.
-        ## The secret must be deployed manually prior to installing this chart.
-        # trustedCertificateSecret:
-        #   secretName: S3Certificate
-        #   key: cert
-    ## Uncomment this section to adjust the resource allocation for the notebook execution pods.
-    ##
-    # workflow:
-    #   run:
-    #     ## Default resource allocation for execution pods.
-    #     ##
-    #     resources:
-    #       requests:
-    #         cpu: "0.1"
-    #         memory: 2Gi
-    #       limits:
-    #         memory: 2Gi
-    #     ## Resource profiles enable different resource allocations for each execution. They can be specified in the API call creating an execution.
-    #     ## Profile names are fixed and cannot be modified.
-    #     ## To ensure that the scheduling of non-execution pods is not impacted, refer to node-selectors.yaml to configure dedicated nodes for execution pods.
-    #     ## In cloud environments, limit the maximum number of nodes to avoid unexpected costs.
-    #     ## To reserve capacity for resource profiles with high resource demands, set a lower maximum number of workflows to schedule.
-    #     ##
-    #     resourceProfiles:
-    #       low:
-    #         requests:
-    #           cpu: "0.1"
-    #           memory: 4Gi
-    #         limits:
-    #           memory: 4Gi
-    #       medium:
-    #         requests:
-    #           cpu: "0.1"
-    #           memory: 8Gi
-    #         limits:
-    #           memory: 8Gi
-    #       high:
-    #         requests:
-    #           cpu: "0.1"
-    #           memory: 16Gi
-    #         limits:
-    #           memory: 16Gi
+    region: *s3Region
+  ## Uncomment this section to adjust the resource allocation for the notebook execution pods.
+  ##
+  # argo:
+  #   workflow:
+  #     run:
+  #       ## Default resource allocation for execution pods.
+  #       ##
+  #       resources:
+  #         requests:
+  #           cpu: "0.1"
+  #           memory: 2Gi
+  #         limits:
+  #           memory: 2Gi
+  #       ## Resource profiles enable different resource allocations for each execution. They can be specified in the API call creating an execution.
+  #       ## Profile names are fixed and cannot be modified.
+  #       ## To ensure that the scheduling of non-execution pods is not impacted, refer to node-selectors.yaml to configure dedicated nodes for execution pods.
+  #       ## In cloud environments, limit the maximum number of nodes to avoid unexpected costs.
+  #       ## To reserve capacity for resource profiles with high resource demands, set a lower maximum number of workflows to schedule.
+  #       ##
+  #       resourceProfiles:
+  #         low:
+  #           requests:
+  #             cpu: "0.1"
+  #             memory: 4Gi
+  #           limits:
+  #             memory: 4Gi
+  #         medium:
+  #           requests:
+  #             cpu: "0.1"
+  #             memory: 8Gi
+  #           limits:
+  #             memory: 8Gi
+  #         high:
+  #           requests:
+  #             cpu: "0.1"
+  #             memory: 16Gi
+  #           limits:
+  #             memory: 16Gi
 
 
 ## Configuration for Repository Service


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/install-systemlink-enterprise/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

MinIO has been removed from the top-level Helm chart. MinIO can still be used for evaluation purposes, but must be separately installed. This change removes the assumption that MinIO is the default block storage provider from our install templates, attempts to improve the ease of configuring a custom S3 provider, and provides a template and readme to assist with manual MinIO installs.

### Why should this Pull Request be merged?

Provides a migration path away from MinIO as a default block storage provider. 

### What testing has been done?

All configuration was used in configuring internal clusters.
