### PR TITLE
Reduce CPU for Cloud SQL Auth Proxy

### DIFF
--- a/getting-started/templates/GCP/gcp-supplemental-values.yaml
+++ b/getting-started/templates/GCP/gcp-supplemental-values.yaml
@@ -64,7 +64,7 @@ testmonitorservice:
           ## The proxy's CPU use scales linearly with the amount of IO between
           ## the database and the application. Adjust this value based on your
           ## application's requirements.
-          cpu: "0.1"
+          cpu: "0.075"
         limits:
           memory: "100Mi"
 
@@ -297,7 +297,7 @@ dynamicformfields:
           ## The proxy's CPU use scales linearly with the amount of IO between
           ## the database and the application. Adjust this value based on your
           ## application's requirements.
-          cpu: "0.1"
+          cpu: "0.075"
         limits:
           memory: "100Mi"
 


### PR DESCRIPTION
### What does this Pull Request accomplish?

The CPU for Cloud SQL Auth Proxy has been reduced from 100m to 75m for the following service after aligning with owners
1. TestMonitor Service
2. Dynamic Form Fields

### Why should this Pull Request be merged?

The reduced CPU of 75m should be adequate as per the testing done.

### What testing has been done?

NA