### PR TITLE
Add nessie credential secret to values template

### DIFF
--- a/getting-started/templates/systemlink-secrets.yaml
+++ b/getting-started/templates/systemlink-secrets.yaml
@@ -243,6 +243,13 @@ dataframeservice:
       ## Access key for the S3 instance.
       ##
       accessKey: *s3Password
+    ## Credentials for nessie.
+    ##
+    nessie:
+      ## Bearer token for dremio to authenticate with nessie.
+      ## Can be any random value.
+      ##
+      bearerToken: ""  # <ATTENTION>
     ## Credentials for the MongoDB cluster.
     ##
     mongodb:

--- a/getting-started/templates/systemlink-values.yaml
+++ b/getting-started/templates/systemlink-values.yaml
@@ -723,6 +723,16 @@ dataframeservice:
     # <ATTENTION> This must be set to the region of the S3 instance.
     ##
     region: *s3Region
+  ## Configure nessie.
+  ##
+  nessie:
+    auth:
+      ## Name of the secret containing the nessie credentials
+      ##
+      secretName: nidataframe-nessie-credentials
+      ## The name of the key in the above secret whose value contains the bearer token.
+      ##
+      bearerTokenKey: bearerToken
 
   ## Configure Dremio access
   ##


### PR DESCRIPTION
- [x] This contribution adheres to
      [CONTRIBUTING.md](https://github.com/ni/install-systemlink-enterprise/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Adds documentation for the DFS Nessie bearer token.

### Why should this Pull Request be merged?

The secret is now required and users must specify a value.

### What testing has been done?

PR
