### PR TITLE
Add storage to feedservice, move s3 under storage

### DIFF
--- a/getting-started/templates/systemlink-values.yaml
+++ b/getting-started/templates/systemlink-values.yaml
@@ -845,30 +845,36 @@ saltmaster:
 ## Feed configuration.
 ##
 feedservice:
-  ## Configure S3 access.
+  ## Configure file storage settings
   ##
-  s3:
-    ## Secret name for S3 credentials.
+  storage:
+    ## Storage type. Supported values: "s3".
     ##
-    secretName: "feeds-s3-credentials"
-    ## The name of the S3 bucket that the service should connect to.
+    type: "s3"
+    ## Configure S3 access.
     ##
-    bucket: "systemlink-feeds"
-    ## S3 connection scheme.
-    ##
-    scheme: *s3Scheme
-    ## Set this value to connect to an external S3 instance.
-    ##
-    host: *s3Host
-    ## Set this value to connect to an S3 instance which is internal to the cluster. Ignored if host is set.
-    ##
-    service: *s3ServiceName
-    ## S3 Port
-    ##
-    port: *s3Port
-    ## S3 Region
-    ##
-    region: *s3Region
+    s3:
+      ## Secret name for S3 credentials.
+      ##
+      secretName: "feeds-s3-credentials"
+      ## The name of the S3 bucket that the service should connect to.
+      ##
+      bucket: "systemlink-feeds"
+      ## S3 connection scheme.
+      ##
+      scheme: *s3Scheme
+      ## Set this value to connect to an external S3 instance.
+      ##
+      host: *s3Host
+      ## Set this value to connect to an S3 instance which is internal to the cluster. Ignored if host is set.
+      ##
+      service: *s3ServiceName
+      ## S3 Port
+      ##
+      port: *s3Port
+      ## S3 Region
+      ##
+      region: *s3Region
   ## Proxy configuration to be used when the service needs to go through a proxy to have access to external services like ni.com.
   httpProxy:
     ## @param httpProxy.address Address of the HTTP proxy in the $host:$port format. Example: "1.1.1.1:2222"

--- a/getting-started/templates/systemlink-values.yaml
+++ b/getting-started/templates/systemlink-values.yaml
@@ -845,19 +845,19 @@ saltmaster:
 ## Feed configuration.
 ##
 feedservice:
-  ## Configure file storage settings
+  ## Configures file storage settings.
   ##
   storage:
-    ## Storage type. Supported values: "s3".
+    ## Specifies which storage to use. Supports "S3".
     ##
     type: "s3"
-    ## Configure S3 access.
+    ## Configures S3 access.
     ##
     s3:
       ## Secret name for S3 credentials.
       ##
       secretName: "feeds-s3-credentials"
-      ## The name of the S3 bucket that the service should connect to.
+      ## The name of an S3 bucket. The service will connect to this bucket.
       ##
       bucket: "systemlink-feeds"
       ## S3 connection scheme.
@@ -866,7 +866,7 @@ feedservice:
       ## Set this value to connect to an external S3 instance.
       ##
       host: *s3Host
-      ## Set this value to connect to an S3 instance which is internal to the cluster. Ignored if host is set.
+      ## Set this value to connect to an internal S3 instance from the cluster. The feedservice ignores the value if the host is set.
       ##
       service: *s3ServiceName
       ## S3 Port


### PR DESCRIPTION
- [x ] This contribution adheres to
      [CONTRIBUTING.md](https://github.com/ni/install-systemlink-enterprise/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

A new storage setting is introduced under feedservice. It has a type property that specifies the storge service to use.
The s3 settings under feedservice are moved under storage.s3

### Why should this Pull Request be merged?

Document changes in existing settings.

### What testing has been done?


