### PR TITLE
Update WebServer rate limit in the pilot config

### DIFF
--- a/getting-started/templates/pilot-sizing.yaml
+++ b/getting-started/templates/pilot-sizing.yaml
@@ -703,7 +703,7 @@ webserver:
     targetCPUUtilizationPercentage: 80
     targetMemoryUtilizationPercentage: 90
 
-  # Increase default rate limit to adjust for reduced node count.
+  # Increases the default rate limit to adjust for the reduction in node count.
   rateLimit:
     byUser:
       apiRequestsPerSecond: "30"

--- a/getting-started/templates/pilot-sizing.yaml
+++ b/getting-started/templates/pilot-sizing.yaml
@@ -703,6 +703,11 @@ webserver:
     targetCPUUtilizationPercentage: 80
     targetMemoryUtilizationPercentage: 90
 
+  # Increase default rate limit to adjust for reduced node count.
+  rateLimit:
+    byUser:
+      apiRequestsPerSecond: "30"
+
   redis-cluster:
     cluster:
       nodes: 3


### PR DESCRIPTION
- [x] This contribution adheres to
      [CONTRIBUTING.md](https://github.com/ni/install-systemlink-enterprise/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

The default rate limit for the web server assumes a minimum deployment of 4 pods. The pilot config only deploys 2 pods. I'm concerned that particularly busy pages in the UI could start seeing 429 errors with this sizing. Increasing the rate limit should avoid this.

### Why should this Pull Request be merged?

Tweak pilot configuration file.

### What testing has been done?

N/A
