### PR TITLE
Add storage to NbExecService, move s3 under storage

### DIFF
--- a/getting-started/templates/systemlink-values.yaml
+++ b/getting-started/templates/systemlink-values.yaml
@@ -1029,29 +1029,36 @@ argoworkflows:
 ##
 nbexecservice:
   maxNumberOfWorkflowsToSchedule: *workflowParallelism
-  ## Configure S3 access.
+  ## Configures file storage settings.
   ##
-  s3:
-    ## Secret name for S3 credentials.
+  storage: 
+    ## Specifies which storage to use. Supports "S3".
     ##
-    secretName: "nbexecservice-s3-credentials"
-    ## The name of the S3 bucket that the service should connect to.
+    type: "s3"
+    ## Configures S3 access.
     ##
-    bucket: "systemlink-executions"
-    ## S3 connection scheme.
-    ##
-    scheme: *s3Scheme
-    ## Set this value to connect to an external S3 instance.
-    ##
-    host: *s3Host
-    ## Set this value to connect to an S3 instance which is internal to the cluster. Ignored if host is set.
-    ##
-    service: *s3ServiceName
-    ## S3 Port
-    port: *s3Port
-    ## S3 Region
-    ##
-    region: *s3Region
+    s3:
+      ## Secret name for S3 credentials.
+      ##
+      secretName: "nbexecservice-s3-credentials"
+      ## The name of the S3 bucket that the service should connect to.
+      ##
+      bucket: "systemlink-executions"
+      ## S3 connection scheme.
+      ##
+      scheme: *s3Scheme
+      ## Set this value to connect to an external S3 instance.
+      ##
+      host: *s3Host
+      ## Set this value to connect to an S3 instance which is internal to the cluster. Ignored if host is set.
+      ##
+      service: *s3ServiceName
+      ## S3 Port
+      ##
+      port: *s3Port
+      ## S3 Region
+      ##
+      region: *s3Region
   ## Uncomment this section to adjust the resource allocation for the notebook execution pods.
   ##
   # argo:

--- a/getting-started/templates/systemlink-values.yaml
+++ b/getting-started/templates/systemlink-values.yaml
@@ -1032,7 +1032,7 @@ nbexecservice:
   ## Configures file storage settings.
   ##
   storage: 
-    ## Specifies which storage to use. Supports "S3".
+    ## Set this value to specify the storage type. The NbExecService supports "S3".
     ##
     type: "s3"
     ## Configures S3 access.
@@ -1050,7 +1050,7 @@ nbexecservice:
       ## Set this value to connect to an external S3 instance.
       ##
       host: *s3Host
-      ## Set this value to connect to an S3 instance which is internal to the cluster. Ignored if host is set.
+      ## Set this value to connect to an S3 instance that is internal to the cluster. The NbExecService ignores the value if the host is set.
       ##
       service: *s3ServiceName
       ## S3 Port


### PR DESCRIPTION
- [x] This contribution adheres to
      [CONTRIBUTING.md](https://github.com/ni/install-systemlink-enterprise/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

A new storage setting is introduced under our services (file ingestion service, feeds, DFS) . It has a type property that specifies the storge service to use.
The s3 settings under NbExecService are moved under storage.s3


### Why should this Pull Request be merged?

Document changes in existing settings.

### What testing has been done?

N/A
