### PR TITLE
Pilot config: Reduce DataFrame Service ingestion config

### DIFF
--- a/getting-started/templates/pilot-sizing.yaml
+++ b/getting-started/templates/pilot-sizing.yaml
@@ -135,6 +135,34 @@ dataframeservice:
     targetCPUUtilizationPercentage: 60
     targetMemoryUtilizationPercentage: 70
 
+  ingestion:
+    # Configuration for the pool of streams used to upload table data to storage such as S3 or
+    # Azure Blob Storage.
+    streamPool:
+      # Size of each buffer in the stream pool. This value must be greater than zero.
+      # When "storage.type" is "s3", this value must be greater or equal to "storage.s3.minimumPartSize".
+      # The product of this value and "maximumPooledStreams", must be less than the memory requested for
+      # the service in "resources.requests.memory".
+      bufferSize: 15MiB
+      # Maximum number of streams that will be pooled.
+      # The recommendation is to provide the same number of pool streams as the limit of requests that can be processed
+      # in "rateLimits.ingestion.requestsLimit".
+      # The product of this value and "bufferSize", must be less than the memory requested for
+      # the service in "resources.requests.memory".
+      # WARNING: Setting this value 0 would leave the pool unbounded, which could cause high memory usage.
+      maximumPooledStreams: 2
+    # Configuration for the S3 ingestion backend.
+    s3Backend:
+      # Approximate number of values to buffer into memory for writing to a parquet row group.
+      # Values that are too small may produce parquet files that can't be queried. Larger
+      # values require additional memory.
+      rowGroupSize: "125000"
+
+  rateLimits:
+    ingestion:
+      # Number of concurrent requests that a single pod can serve for ingesting data.
+      requestsLimit: 2
+
   queryEngine:
     workloadManagement:
       writeQueue:

--- a/getting-started/templates/pilot-sizing.yaml
+++ b/getting-started/templates/pilot-sizing.yaml
@@ -168,6 +168,7 @@ dataframeservice:
   rateLimits:
     ingestion:
       # Number of concurrent requests that a single pod can serve for ingesting data.
+      # Subsequent requests will be put in a queue.
       requestsLimit: 2
       # Size of the queue for concurrent requests. If a request arrives to a pod with a full queue,
       # the pod will return a 429 Error code.

--- a/getting-started/templates/pilot-sizing.yaml
+++ b/getting-started/templates/pilot-sizing.yaml
@@ -156,11 +156,12 @@ dataframeservice:
       # Approximate number of values to buffer into memory for writing to a parquet row group.
       # Values that are too small may produce parquet files that can't be queried. Larger
       # values require additional memory.
+      # When adjusting this value, adjust requestBodySizeLimit proportionally.
       rowGroupSize: "125000"
   
   # Limits the body size for requests. The ingress may also impose a request body size
-  # limit, which should be set to the same value. When modifying ingestion.s3Backend.rowGroupSize,
-  # make a proportional change to this value.
+  # limit, which should be set to the same value. 
+  # When modifying ingestion.s3Backend.rowGroupSize, make a proportional change to this value.
   # Accepts units in "MiB" (Mebibytes, 1024 KiB) or in "MB" (Megabytes, 1000 KB)
   requestBodySizeLimit: 32MiB
 

--- a/getting-started/templates/pilot-sizing.yaml
+++ b/getting-started/templates/pilot-sizing.yaml
@@ -157,11 +157,20 @@ dataframeservice:
       # Values that are too small may produce parquet files that can't be queried. Larger
       # values require additional memory.
       rowGroupSize: "125000"
+  
+  # Limits the body size for requests. The ingress may also impose a request body size
+  # limit, which should be set to the same value. When modifying ingestion.s3Backend.rowGroupSize,
+  # make a proportional change to this value.
+  # Accepts units in "MiB" (Mebibytes, 1024 KiB) or in "MB" (Megabytes, 1000 KB)
+  requestBodySizeLimit: 32MiB
 
   rateLimits:
     ingestion:
       # Number of concurrent requests that a single pod can serve for ingesting data.
       requestsLimit: 2
+      # Size of the queue for concurrent requests. If a request arrives to a pod with a full queue,
+      # the pod will return a 429 Error code.
+      queueSize: 2
 
   queryEngine:
     workloadManagement:

--- a/getting-started/templates/sizing-examples/data-management-sizing-example.yaml
+++ b/getting-started/templates/sizing-examples/data-management-sizing-example.yaml
@@ -29,8 +29,37 @@ dataframeservice:
       targetCPUUtilizationPercentage: 60
       targetMemoryUtilizationPercentage: 80
 
+  # Limits the body size for requests. The ingress may also impose a request body size
+  # limit, which should be set to the same value. 
+  # When modifying ingestion.s3Backend.rowGroupSize, make a proportional change to this value.
+  # Accepts units in "MiB" (Mebibytes, 1024 KiB) or in "MB" (Megabytes, 1000 KB)
+  requestBodySizeLimit: 256MiB
+
   ## Configuration for DataFrame writes
   ingestion:
+    # Configuration for the pool of streams used to upload table data to storage such as S3 or
+    # Azure Blob Storage.
+    streamPool:
+      # Size of each buffer in the stream pool. This value must be greater than zero.
+      # When "storage.type" is "s3", this value must be greater or equal to "storage.s3.minimumPartSize".
+      # The product of this value and "maximumPooledStreams", must be less than the memory requested for
+      # the service in "resources.requests.memory".
+      bufferSize: 15MiB
+      # Maximum number of streams that will be pooled.
+      # The recommendation is to provide the same number of pool streams as the limit of requests that can be processed
+      # in "rateLimits.ingestion.requestsLimit".
+      # The product of this value and "bufferSize", must be less than the memory requested for
+      # the service in "resources.requests.memory".
+      # WARNING: Setting this value 0 would leave the pool unbounded, which could cause high memory usage.
+      maximumPooledStreams: 20
+    # Configuration for the S3 ingestion backend.
+    s3Backend:
+      # Approximate number of values to buffer into memory for writing to a parquet row group.
+      # Values that are too small may produce parquet files that can't be queried. Larger
+      # values require additional memory.
+      # When adjusting this value, adjust requestBodySizeLimit proportionally.
+      rowGroupSize: "1000000"
+
     ## @param dataframeservice.ingestion.maxColumnCount The maximum number of columns that a data table may be created with.
     ## Attempting to create a table with more columns than the specified limit will result in a 400 Bad Request response.
     maxColumnCount: 2500
@@ -41,7 +70,6 @@ dataframeservice:
     ## number of columns, the resources available to Dremio, and the number of executors.
     ## The default is 1 billion rows. This value must be greater than zero and less than 2147483648.
     maxRowCount: "1000000000"
-
 
   ## Dremio configuration
   sldremio:

--- a/getting-started/templates/sizing-examples/data-management-sizing-example.yaml
+++ b/getting-started/templates/sizing-examples/data-management-sizing-example.yaml
@@ -71,6 +71,15 @@ dataframeservice:
     ## The default is 1 billion rows. This value must be greater than zero and less than 2147483648.
     maxRowCount: "1000000000"
 
+  rateLimits:
+    ingestion:
+      # Number of concurrent requests that a single pod can serve for ingesting data.
+      # Subsequent requests will be put in a queue.
+      requestsLimit: 20
+      # Size of the queue for concurrent requests. If a request arrives to a pod with a full queue,
+      # the pod will return a 429 Error code.
+      queueSize: 0
+
   ## Dremio configuration
   sldremio:
     ## Resource requests for the coordinator.


### PR DESCRIPTION
- [X] This contribution adheres to
      [CONTRIBUTING.md](https://github.com/ni/install-systemlink-enterprise/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Reduces the DataFrame Service ingestion configuration to make pilot configurations more stable.

### Why should this Pull Request be merged?

The current configuration is not stable. With these values, we've gotten escalations where ingestion requests have failed with `OutOfMemory` exceptions. The default memory request for the DataFrame Service is 4 GB, and the ingestion configuration is tuned to expect 4 GB of memory. The pilot config sets the default memory request to 512 Mi, but we forgot to reduce the ingestion configuration proportionally.

Users may hit issues ingesting large amounts of data, or many tables in parallel, with the adjusted config. That should be a clear indication that they're outside the scale that the pilot config is intended to support. The ingestion concurrency limit in particular is likely to be something pilot deployment users will notice.

### What testing has been done?

- Successfully deployed to Minikube with this config
- I tried to do some modest performance testing, but our k6 tests aren't in a good state. With two pods, I was able to concurrently append 10k rows to three different tables in 1k batches. The tables had 100 columns.
