### PR TITLE
Add DFF health check path to ingress supplementals

### DIFF
--- a/getting-started/templates/AWS/aws_supplemental_values.yml
+++ b/getting-started/templates/AWS/aws_supplemental_values.yml
@@ -44,6 +44,11 @@ dashboardhost:
     annotations:
       alb.ingress.kubernetes.io/healthcheck-path: "/api/health"
 
+dynamicformfields:
+  ingress:
+    annotations:
+      alb.ingress.kubernetes.io/healthcheck-path: "/nidynamicformfields/up"
+
 testmonitorservice:
   ingress:
     annotations:

--- a/getting-started/templates/Azure/azure_supplemental_values.yml
+++ b/getting-started/templates/Azure/azure_supplemental_values.yml
@@ -48,6 +48,11 @@ dashboardhost:
     annotations:
       appgw.ingress.kubernetes.io/health-probe-path: "/api/health"
 
+dynamicformfields:
+  ingress:
+    annotations:
+      appgw.ingress.kubernetes.io/health-probe-path: "/nidynamicformfields/up"
+
 testmonitorservice:
   ingress:
     annotations:


### PR DESCRIPTION
- [x] This contribution adheres to
      [CONTRIBUTING.md](https://github.com/ni/install-systemlink-enterprise/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Adds the `dynamicformfields` health check annotations to the Azure and AWS ingress controller supplemental values files

### Why should this Pull Request be merged?

Like several other services, dynamicformfields does not use a standard health route (pending readiness probe overhaul) and such it needs to be specified for the ALB to allow routing to the DFF pods. We have supplemental values files for doing this for the Azure and AWS ALBs as starting points.

### What testing has been done?

Supplement only change following standard patterns, no extra testing needed
