### PR TITLE
Remove the SystemsManagementEventService from the documentation

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -64,7 +64,6 @@
         "sldremio",
         "slnotebook",
         "strimzi",
-        "sysmgmtevent",
         "systemlink",
         "systemlinkadmin",
         "systemsmamagement",

--- a/getting-started/templates/node-selectors.yaml
+++ b/getting-started/templates/node-selectors.yaml
@@ -256,11 +256,6 @@ swaggerapi:
   tolerations: *servicesTolerations
   affinity: *servicesAffinity
 
-sysmgmtevent:
-  nodeSelector: *servicesNodeSelector
-  tolerations: *servicesTolerations
-  affinity: *servicesAffinity
-
 systems:
   nodeSelector: *servicesNodeSelector
   tolerations: *servicesTolerations

--- a/getting-started/templates/pilot-sizing.yaml
+++ b/getting-started/templates/pilot-sizing.yaml
@@ -556,14 +556,6 @@ swaggerapi:
     targetCPUUtilizationPercentage: 60
     targetMemoryUtilizationPercentage: 70
 
-sysmgmtevent:
-  resources:
-    requests:
-      memory: "256Mi"
-      cpu: 100m
-    limits:
-      memory: "512Mi"
-
   autoscaling:
     enabled: true
     minReplicas: 2

--- a/getting-started/templates/systemlink-secrets.yaml
+++ b/getting-started/templates/systemlink-secrets.yaml
@@ -405,24 +405,6 @@ smtp:
       username: "" # <ATTENTION>
       password: "" # <ATTENTION>
 
-## Secret configuration for the systems event manager.
-##
-sysmgmtevent:
-  secrets:
-    ## Credentials for the MongoDB cluster.
-    ##
-    mongodb:
-      ## Root user password for the database cluster.
-      ##
-      rootPassword: ""  # <ATTENTION>
-      ## Limited user password to allow the service to access the database. This password cannot contain commas or any character that must be escaped in a URL.
-      ##
-      servicePassword: ""  # <ATTENTION>
-      ## Key used to authenticate pods in the database cluster.
-      ## Refer to the MongoDB documentation for key generation: https://www.mongodb.com/docs/manual/tutorial/enforce-keyfile-access-control-in-existing-replica-set/#create-a-keyfile
-      ##
-      replicaSetKey: ""  # <ATTENTION>
-
 ## Secret configuration for salt master.
 ##
 saltmaster:

--- a/ni-dictionary.txt
+++ b/ni-dictionary.txt
@@ -492,7 +492,6 @@ Suriya
 Suseendran
 Swashbuckle
 SWIF
-sysmgmtevent
 SystemLink
 SYSTEMLINK
 systemsstate


### PR DESCRIPTION
- [x] This contribution adheres to
      [CONTRIBUTING.md](https://github.com/ni/install-systemlink-enterprise/blob/master/CONTRIBUTING.md).

TODO: Check the above box with an 'x' indicating you've read and followed
[CONTRIBUTING.md](https://github.com/ni/install-systemlink-enterprise/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

It removes references to **SystemsManagementEventService**, which is no longer in the product since we use RabbitMQ.

### Why should this Pull Request be merged?

To keep the documentation accurate and remove outdated information.

### What testing has been done?
N/A