### PR TITLE
Fix DFS streamPool values in systemlink-values

### DIFF
--- a/getting-started/templates/systemlink-values.yaml
+++ b/getting-started/templates/systemlink-values.yaml
@@ -678,8 +678,8 @@ dataframeservice:
       queueSize: 0
 
   ingestion:
-    ## Configuration for the pool of streams used to upload table data to storage such as S3 or
-    ## Azure Blob Storage.
+    ## Configuration for the pool of streams used to upload table data to a storage service such
+    ## as S3 or Azure Blob Storage.
     streamPool:
       ## Maximum number of streams that will be pooled.
       ## The recommendation is to provide the same number of pool streams as the limit of requests that

--- a/getting-started/templates/systemlink-values.yaml
+++ b/getting-started/templates/systemlink-values.yaml
@@ -678,9 +678,9 @@ dataframeservice:
       queueSize: 0
 
   ingestion:
-    ## Configuration for the pool of streams used to upload the data to S3.
-    ##
-    s3StreamPool:
+    ## Configuration for the pool of streams used to upload table data to storage such as S3 or
+    ## Azure Blob Storage.
+    streamPool:
       ## Maximum number of streams that will be pooled.
       ## The recommendation is to provide the same number of pool streams as the limit of requests that
       ## can be processed in "rateLimits.ingestion.requestsLimit".


### PR DESCRIPTION
- [X] This contribution adheres to
      [CONTRIBUTING.md](https://github.com/ni/install-systemlink-enterprise/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Renames `dataframeservice.ingestion.s3StreamPool.maximumPooledStreams` to `dataframeservice.ingestion.streamPool.maximumPooledStreams` in systemlink-values.yaml.

### Why should this Pull Request be merged?

In 2025-05, the dataframeservice chart had a [breaking change](https://github.com/ni/install-systemlink-enterprise/tree/main/release-notes/2025-05#helm-chart-breaking-changes). Setting the old value leads to a Helm install error.

### What testing has been done?

Ran `helm template` using the updated systemlink-values.yaml.
