### PR TITLE
Extract S3 values into separate YAML files

### DIFF
--- a/getting-started/templates/AWS/aws-secrets.yaml
+++ b/getting-started/templates/AWS/aws-secrets.yaml
@@ -1,0 +1,51 @@
+## Additional AWS secret values for the systemlink Helm chart.
+## This is a YAML-formatted file.
+
+## The following values are typically shared across multiple configurations. The values
+## here are not used directly as configuration but provide a convenient way to share
+## common configuration throughout this file. Individual references to these values can
+## be overridden with custom values if required.
+
+## User name for S3 access
+# <ATTENTION> Configure S3 credentials and region.
+##
+s3User: &s3User ""
+## Password for s3 access
+##
+s3Password: &s3Password ""
+## Default region for the S3 instance.
+##
+s3DefaultRegion: &s3DefaultRegion "us-east-1"
+
+dataframeservice:
+  secrets:
+    s3:
+      accessKeyId: *s3User
+      accessKey: *s3Password
+
+  sldremio:
+    distStorage:
+      aws:
+        credentials:
+          accessKey: *s3User
+          secret: *s3Password
+
+feedservice:
+  secrets:
+    s3:
+      accessKeyId: *s3User
+      accessKey: *s3Password
+      defaultRegion: *s3DefaultRegion
+
+fileingestion:
+  secrets:
+    s3:
+      accessKeyId: *s3User
+      accessKey: *s3Password
+      defaultRegion: *s3DefaultRegion
+
+nbexecservice:
+  secrets:
+    s3:
+      accessKeyId: *s3User
+      accessKey: *s3Password

--- a/getting-started/templates/AWS/aws_supplemental_values.yml
+++ b/getting-started/templates/AWS/aws_supplemental_values.yml
@@ -1,3 +1,16 @@
+# Values overrides for AWS deployments that configure services to use S3 for storage.
+# It also provides annotations for the Application Load Balancer and SystemLink Enterprise service health checks paths.
+#
+# This file should be passed in as a values file with systemlink-values.yaml, systemlink-secrets.yaml,
+# and aws-secrets.yaml during SLE install. To use an alternative storage service such as MinIO
+# instead of S3, reference OnPrem/storage-values.yaml.
+#
+# The default health check path /up addresses the health probe for most services.
+# Those that diverge from this path are declared below by service.
+# Health check paths should not be modified unless called out in monthly release notes.
+#
+# This is a YAML-formatted file.
+
 global:
   ingress:
     api:
@@ -31,6 +44,25 @@ global:
         # <ATTENTION> - Optional - Uncomment and enter the ARN for the WAFv2 ACL if you are using AWS' Web Application Firewall
         # alb.ingress.kubernetes.io/wafv2-acl-arn:
 
+## The following values are typically shared across multiple configurations. The values
+## here are not used directly as configuration but provide a convenient way to share
+## common configuration throughout this file. Individual references to these values can
+## be overridden with custom values if required.
+
+## Hostname of the S3 service to connect to.
+##
+s3Host: &s3Host "s3.amazonaws.com"
+## Scheme used to access the configured S3 provider ("http" or "https")
+##
+s3Scheme: &s3Scheme "https"
+## Port number of the S3 provider
+##
+s3Port: &s3Port 443
+## Region where S3 storage is located
+# <ATTENTION> To connect to a region other than us-east-1, change this value.
+##
+s3Region: &s3Region "us-east-1"
+
 assetservice:
   ingress:
     annotations:
@@ -58,6 +90,79 @@ dataframeservice:
   ingress:
     annotations:
       alb.ingress.kubernetes.io/healthcheck-path: "/nidataframe/health"
+  storage:
+    type: s3
+    s3:
+      ## The name of an existing S3 bucket for the DataFrame Service to connect to.
+      ##
+      bucket: "systemlink-dataframe"
+      ## Maximum number of concurrent connections to S3 per replica.
+      ##
+      maximumConnections: 32
+      schemeName: *s3Scheme
+      host: *s3Host
+      port: *s3Port
+      region: *s3Region
+  sldremio:
+    distStorage:
+      type: "aws"
+      aws:
+        ## The name of the S3 bucket that Dremio should use for the distributed storage cache.
+        ## The recommendation is to use a dedicated bucket, but this may be the same as the same
+        ## value as "dataframeservice.storage.s3.bucket", in which case "path" should be uncommented.
+        ##
+        bucketName: "systemlink-dataframe-cache"
+        ## The path in the bucket that Dremio will store data. Uncomment when not using a dedicated
+        ## bucket. Adjust the value as desired.
+        ##
+        # path: "/dremio"
+        authentication: "accessKeySecret"
+        # <ATTENTION> When modifying any of the s3Host, s3Scheme, s3Port, or s3Region values to be
+        #             anything except the defaults of s3.amazonaws.com, https, 443, and us-east-1,
+        #             respectively, uncomment the below extraProperties and update each value accordingly.
+        # extraProperties: |
+        #   <property>
+        #     <name>fs.s3a.endpoint</name>
+        #     <description>Set to the hostname and port of the S3 service to connect to (see s3Host and s3Port).</description>
+        #     <value>s3.amazonaws.com:443</value>
+        #   </property>
+        #   <property>
+        #     <name>fs.s3a.connection.ssl.enabled</name>
+        #     <description>True to use HTTPS or false to use HTTP (see s3Scheme).</description>
+        #     <value>true</value>
+        #   </property>
+        #   <property>
+        #     <name>dremio.s3.region</name>
+        #     <description>The region where S3 storage is located (see s3Region).</description>
+        #     <value>us-east-1</value>
+        #   </property>
+
+feedservice:
+  storage:
+    type: "s3"
+    s3:
+      ## The name of the S3 bucket for the Feed Service to connect to.
+      ##
+      bucket: "systemlink-feeds"
+      scheme: *s3Scheme
+      host: *s3Host
+      port: *s3Port
+      region: *s3Region
+
+fileingestion:
+  storage:
+    type: "s3"
+    s3:
+      ## The name of the S3 bucket for the File Ingestion Service to connect to.
+      ##
+      bucket: "systemlink-file-ingestion"
+      ## Set this to true to limit each user to a maximum of 1Gb of file storage.
+      ##
+      storageLimitsEnabled: false
+      scheme: *s3Scheme
+      host: *s3Host
+      port: *s3Port
+      region: *s3Region
 
 saltmaster:
   serviceTCP:
@@ -73,6 +178,17 @@ nbexecservice:
   ingress:
     annotations:
       alb.ingress.kubernetes.io/healthcheck-path: "/ninbexecution/up"
+
+  storage:
+    type: "s3"
+    s3:
+      ## The name of the S3 bucket for the Notebook Execution Service to connect to.
+      ##
+      bucket: "systemlink-executions"
+      scheme: *s3Scheme
+      host: *s3Host
+      port: *s3Port
+      region: *s3Region
 
 notification:
   ingress:

--- a/getting-started/templates/Azure/azure-supplemental-values.yaml
+++ b/getting-started/templates/Azure/azure-supplemental-values.yaml
@@ -1,7 +1,9 @@
 # Values overrides for Azure deployments to configure services to use Azure Blob Storage.
 # It also provides annotations for the Azure application gateway and SystemLink Enterprise service health checks paths.
 #
-# This file should be passed in as a values file with systemlink-secrets and systemlink-values during SLE install.
+# This file should be passed in as a values file with systemlink-values.yaml, systemlink-secrets.yaml,
+# and azure-secrets.yaml during SLE install. To use an alternative storage service such as MinIO
+# instead of Azure Blob Storage, reference OnPrem/storage-values.yaml.
 #
 # Modify "systemlink-ssl-cert" to match the name of your certificate used for the application gateway.
 #
@@ -40,11 +42,6 @@ global:
 ## configuration throughout this file. Individual references to these values can be
 ## overridden with custom values if required.
 
-## The storage backend to use.
-## Set this to "s3" to use the S3 configuration from systemlink-values.yaml instead of
-## using Azure Storage.
-##
-storageType: &storageType "azure"
 ## The Azure Blob Storage host and port to connect to, without the account name.
 # <ATTENTION> To connect to an alternative Azure Storage host such as usgovcloudapi.net,
 #             set both azureBlobApiHost and azureDataLakeApiHost.
@@ -85,7 +82,7 @@ dataframeservice:
       appgw.ingress.kubernetes.io/health-probe-path: "/nidataframe/health"
 
   storage:
-    type: *storageType
+    type: "azure"
     azure:
       ## Name of the Azure Storage account. The account must not have hierarchical namespace
       ## or blob soft delete enabled.
@@ -96,7 +93,6 @@ dataframeservice:
       blobApiHost: *azureBlobApiHost
       dataLakeApiHost: *azureDataLakeApiHost
 
-  # <ATTENTION> When not using Azure Storage, remove this sldremio section.
   sldremio:
     distStorage:
       type: "azureStorage"
@@ -117,7 +113,7 @@ feedservice:
       appgw.ingress.kubernetes.io/health-probe-path: "/nifeed/up"
 
   storage:
-    type: *storageType
+    type: "azure"
     azure:
       # <ATTENTION> Set to the name of an existing Azure storage account to use for the
       #             Feed Service.
@@ -126,7 +122,7 @@ feedservice:
 
 fileingestion:
   storage:
-    type: *storageType
+    type: "azure"
     azure:
       # <ATTENTION> Set to the name of an existing Azure storage account to use for the
       #             File Ingestion Service.
@@ -139,7 +135,7 @@ nbexecservice:
       appgw.ingress.kubernetes.io/health-probe-path: "/ninbexecution/up"
 
   storage:
-    type: *storageType
+    type: "azure"
     azure:
       # <ATTENTION> Set to the name of an existing Azure storage account to use for the
       #             Notebook Execution Service.

--- a/getting-started/templates/Dependencies/MinIO/README.md
+++ b/getting-started/templates/Dependencies/MinIO/README.md
@@ -45,22 +45,21 @@ The same command can be used to apply configuration changes to your release.
 Configuring object storage is part of the standard process of deploying
 SystemLink Enterprise. The following configuration is required to use MinIO.
 
-In `systemlink-values.yaml`:
+In `OnPrem/storage-values.yaml`:
 
-1. Set `s3Host` to an empty string.
-2. Set `s3ServiceName` to `<release>-minio.<namespace>.svc.cluster.local`.
-3. Set `s3Scheme` to `http`.
+1. Set `s3Host` to `<release>-minio.<namespace>.svc.cluster.local`.
+2. Set `s3Scheme` to `http`.
    - Unless you enabled TLS in your MinIO configuration, in which case use
      `https`.
-4. Set `s3Port` to `9000`.
-5. Leave `s3Region` with its default value.
-6. Uncomment the commented-out text for
-   `dataframeservice.sldremio.distStorage.aws.extraProperties` and configure the
-   `fs.s3a.endpoint` and `fs.s3a.connection.ssl.enabled` properties in that
-   section using the value set for s3ServiceName and the TLS configuration for
-   your MinIO instance.
+3. Set `s3Port` to `9000`.
+4. Leave `s3Region` with its default value.
+5. Edit the value for
+   `dataframeservice.sldremio.distStorage.aws.extraProperties`:
+   - Set the `fs.s3a.endpoint` property to `<release>-minio.<namespace>.svc.cluster.local:9000`
+   - Set the `fs.s3a.connection.ssl.enabled` property to `false`, unless you
+     enabled TLS in your MinIO configuration, in which case use `true`.
 
-In `systemlink-secrets.yaml`:
+In `OnPrem/storage-secrets.yaml`:
 
 1. Set `s3User` to the configured root user name.
 2. Set `s3Password` to the configured root password.

--- a/getting-started/templates/OnPrem/storage-secrets.yaml
+++ b/getting-started/templates/OnPrem/storage-secrets.yaml
@@ -1,0 +1,51 @@
+## Additional S3-compatible storage secret values for the systemlink Helm chart.
+## This is a YAML-formatted file.
+
+## The following values are typically shared across multiple configurations. The values
+## here are not used directly as configuration but provide a convenient way to share
+## common configuration throughout this file. Individual references to these values can
+## be overridden with custom values if required.
+
+## User name for S3 access
+# <ATTENTION> Configure S3 credentials and region.
+##
+s3User: &s3User ""
+## Password for s3 access
+##
+s3Password: &s3Password ""
+## Default region for the S3 instance.
+##
+s3DefaultRegion: &s3DefaultRegion "us-east-1"
+
+dataframeservice:
+  secrets:
+    s3:
+      accessKeyId: *s3User
+      accessKey: *s3Password
+
+  sldremio:
+    distStorage:
+      aws:
+        credentials:
+          accessKey: *s3User
+          secret: *s3Password
+
+feedservice:
+  secrets:
+    s3:
+      accessKeyId: *s3User
+      accessKey: *s3Password
+      defaultRegion: *s3DefaultRegion
+
+fileingestion:
+  secrets:
+    s3:
+      accessKeyId: *s3User
+      accessKey: *s3Password
+      defaultRegion: *s3DefaultRegion
+
+nbexecservice:
+  secrets:
+    s3:
+      accessKeyId: *s3User
+      accessKey: *s3Password

--- a/getting-started/templates/OnPrem/storage-values.yaml
+++ b/getting-started/templates/OnPrem/storage-values.yaml
@@ -1,0 +1,124 @@
+# Values overrides for non-AWS deployments that configure services to use S3-compatible storage.
+#
+# This file should be passed in as a values file with systemlink-values.yaml, systemlink-secrets.yaml,
+# and storage-secrets.yaml during SLE install.
+#
+# This is a YAML-formatted file.
+
+## The following values are typically shared across multiple configurations. The values
+## here are not used directly as configuration but provide a convenient way to share
+## common configuration throughout this file. Individual references to these values can
+## be overridden with custom values if required.
+
+## Hostname of an external S3 provider.
+# <ATTENTION> To connect to an external S3 provider, set s3Host, s3Scheme, s3Port and s3Region.
+##
+s3Host: &s3Host ""
+## Service name of an in-cluster S3 provider.
+# <ATTENTION> To connect to an S3 provider within the same cluster, set s3ServiceName, s3Scheme,
+#             s3Port and s3Region, and set s3Host to an empty string.
+##
+s3ServiceName: &s3ServiceName ""
+## Scheme used to access the configured S3 provider ("http" or "https")
+##
+s3Scheme: &s3Scheme "https"
+## Port number of the S3 provider
+##
+s3Port: &s3Port 443
+## Region where S3 storage is located
+##
+s3Region: &s3Region "us-east-1"
+
+dataframeservice:
+  storage:
+    type: s3
+    s3:
+      ## The name of an existing S3 bucket for the DataFrame Service to connect to.
+      ##
+      bucket: "systemlink-dataframe"
+      ## Maximum number of concurrent connections to S3 per replica.
+      ##
+      maximumConnections: 32
+      schemeName: *s3Scheme
+      host: *s3Host
+      service: *s3ServiceName
+      port: *s3Port
+      region: *s3Region
+  sldremio:
+    distStorage:
+      type: "aws"
+      aws:
+        ## The name of the S3 bucket that Dremio should use for the distributed storage cache.
+        ## The recommendation is to use a dedicated bucket, but this may be the same as the same
+        ## value as "dataframeservice.storage.s3.bucket", in which case "path" should be uncommented.
+        ##
+        bucketName: "systemlink-dataframe-dremio"
+        ## The path in the bucket that Dremio will store data. Uncomment when not using a dedicated
+        ## bucket. Adjust the value as desired.
+        ##
+        # path: "/dremio"
+        authentication: "accessKeySecret"
+        extraProperties: |
+          <property>
+            <name>fs.s3a.endpoint</name>
+            <description>Set to the hostname and port of the S3 service to connect to (see s3Host and s3Port).</description>
+            <value><ATTENTION>set to the FQDN of the S3 endpoint, including the port, but without an HTTP or HTTPS prefix. Example: {svc-name}.{namespace}.svc.cluster.local:9000.</value>
+          </property>
+          <property>
+            <name>fs.s3a.path.style.access</name>
+            <description>Value has to be set to true.</description>
+            <value>true</value>
+          </property>
+          <property>
+            <name>dremio.s3.compat</name>
+            <description>Value has to be set to true.</description>
+            <value>true</value>
+          </property>
+          <property>
+            <name>fs.s3a.connection.ssl.enabled</name>
+            <description>True to use HTTPS or false to use HTTP (see s3Scheme).</description>
+            <!--<ATTENTION> When modifying s3Scheme to be http, change this value to false.-->
+            <value>true</value>
+          </property>
+
+feedservice:
+  storage:
+    type: "s3"
+    s3:
+      ## The name of the S3 bucket for the Feed Service to connect to.
+      ##
+      bucket: "systemlink-feeds"
+      scheme: *s3Scheme
+      host: *s3Host
+      service: *s3ServiceName
+      port: *s3Port
+      region: *s3Region
+
+fileingestion:
+  storage:
+    type: "s3"
+    s3:
+      ## The name of the S3 bucket for the File Ingestion Service to connect to.
+      ##
+      bucket: "systemlink-file-ingestion"
+      ## Set this to true to limit each user to a maximum of 1Gb of file storage.
+      ##
+      storageLimitsEnabled: false
+      scheme: *s3Scheme
+      host: *s3Host
+      service: *s3ServiceName
+      port: *s3Port
+      region: *s3Region
+
+nbexecservice:
+  storage:
+    type: "s3"
+    s3:
+      ## The name of the S3 bucket for the Notebook Execution Service to connect to.
+      ##
+      bucket: "systemlink-executions"
+      scheme: *s3Scheme
+      host: *s3Host
+      service: *s3ServiceName
+      port: *s3Port
+      region: *s3Region

--- a/getting-started/templates/systemlink-secrets.yaml
+++ b/getting-started/templates/systemlink-secrets.yaml
@@ -1,6 +1,9 @@
-
-
-## Default secret values for the systemlink Helm chart.
+## Default secret values for the systemlink Helm chart. Object storage must be configured separately:
+##
+## - When hosted on Amazon Web Services, reference AWS/aws-secrets.yml.
+## - When hosted on Azure, reference Azure/azure-secrets.yaml.
+## - When self-hosted, reference OnPrem/storage-secrets.yaml.
+##
 ## This is a YAML-formatted file.
 ## Declare override values for variables.
 
@@ -23,21 +26,6 @@ global:
       #
       # If `global.mongodb.install` is `true` leave the connection string as a blank string or comment it out.
       connection_string: ""
-
-## The following values are typically shared across multiple configurations. The values
-## here are not used directly as configuration but provide a convenient way to share
-## common configuration throughout this file. Individual references to these values can
-## be overridden with custom values if required.
-##
-## User name for S3 access
-# <ATTENTION> Configure S3 credentials. To use Azure Storage, ignore these values and
-#             reference Azure/azure-secrets.yaml.
-##
-s3User: &s3User ""
-## Password for s3 access
-s3Password: &s3Password ""
-##
-s3DefaultRegion: &s3DefaultRegion "us-east-1"
 
 ## Secrets that apply to the entire application.
 ##
@@ -238,15 +226,6 @@ dashboardhost:
 ##
 dataframeservice:
   secrets:
-    ## Access key information for S3 access.
-    ##
-    s3:
-      ## Access key ID for the S3 instance.
-      ##
-      accessKeyId: *s3User
-      ## Access key for the S3 instance.
-      ##
-      accessKey: *s3Password
     ## Credentials for nessie.
     ##
     nessie:
@@ -276,35 +255,11 @@ dataframeservice:
       ## The password for the Dremio instance.
       ##
       password: ""  # <ATTENTION>
-  sldremio:
-    # Dremio distributed storage configuration. This must be configured for the service to perform acceptably.
-    # See https://github.com/dremio/dremio-cloud-tools/blob/master/charts/dremio_v2/docs/Values-Reference.md#distributed-storage-values
-    # Configure this section as appropriate for your environment. The configuration below
-    # assumes the service is being connected to Amazon S3 or an equivalent, like MinIO.
-    # Note: this only partially configures distributed storage. See the rest of the configuration in
-    # systemlink-values.yaml under dataframeservice.sldremio.distStorage.
-    distStorage:
-      aws:
-        credentials:
-          accessKey: *s3User
-          secret: *s3Password
 
 ## Secret configuration for feedservice
 ##
 feedservice:
   secrets:
-    ## Access key information for S3 access.
-    ##
-    s3:
-      ## Access key ID for the S3 instance.
-      ##
-      accessKeyId: *s3User
-      ## Access key for the S3 instance.
-      ##
-      accessKey: *s3Password
-      ## Default region for the S3 instance.
-      ##
-      defaultRegion: *s3DefaultRegion
     ## Credentials for the MongoDB cluster.
     ##
     mongodb:
@@ -329,18 +284,6 @@ fileingestion:
     ## Cryptographic key to be used for encryption of download tokens. This key should have a length of at least 32 bytes.
     ##
     downloadTokenEncryptionKey: "" # <ATTENTION>
-    ## Access key information for S3 access.
-    ##
-    s3:
-      ## Access key ID for the S3 instance.
-      ##
-      accessKeyId: *s3User
-      ## Access key for the S3 instance.
-      ##
-      accessKey: *s3Password
-      ## Default region for the S3 instance.
-      ##
-      defaultRegion: *s3DefaultRegion
     ## Credentials for the MongoDB cluster.
     ##
     mongodb:
@@ -359,15 +302,6 @@ fileingestion:
 ##
 nbexecservice:
   secrets:
-    ## Access key information for S3 access.
-    ##
-    s3:
-      ## Access key ID for the S3 instance.
-      ##
-      accessKeyId: *s3User
-      ## Access key for the S3 instance.
-      ##
-      accessKey: *s3Password
     mongodb:
       ## Root user password for the database cluster.
       ##

--- a/getting-started/templates/systemlink-values.yaml
+++ b/getting-started/templates/systemlink-values.yaml
@@ -1,4 +1,9 @@
-## Default values for systemlink.
+## Default values for systemlink. Object storage must be configured separately:
+##
+## - When hosted on Amazon Web Services, reference AWS/aws_supplemental_values.yml.
+## - When hosted on Azure, reference Azure/azure-supplemental-values.yaml.
+## - When self-hosted, reference OnPrem/storage-values.yaml.
+##
 ## This is a YAML-formatted file.
 ## Declare override values for variables.
 
@@ -123,31 +128,6 @@ global:
   ## Deploy the certificate stored in apiHostCertificateSecret to all managed systems.
   ##
   deployApiHostCertificateToSystems: false
-
-## The following values are typically shared across multiple configurations. The values
-## here are not used directly as configuration but provide a convenient way to share
-## common configuration throughout this file. Individual references to these values can
-## be overridden with custom values if required.
-##
-## Hostname of an external S3 provider.
-# <ATTENTION> To connect to an external S3 provider, set s3Host, s3Scheme, s3Port and s3Region.
-#             To use Azure Storage, ignore these values and reference Azure/azure-supplemental-values.yaml.
-##
-s3Host: &s3Host "s3.amazonaws.com"
-## Service name of an on-cluster S3 provider.
-# <ATTENTION> To connect to an S3 provider within the same cluster, set s3ServiceName, s3Scheme, s3Port and s3Region,
-#             and set s3Host to an empty string.
-##
-s3ServiceName: &s3ServiceName ""
-## Schema used to access the configured S3 provider ("http" or "https")
-##
-s3Scheme: &s3Scheme "https"
-## Port number of the S3 provider
-##
-s3Port: &s3Port 443
-## Region where S3 storage is located
-##
-s3Region: &s3Region "us-east-1"
 
 ## Core configuration for the RabbitMQ message broker
 ##
@@ -671,7 +651,7 @@ dataframeservice:
       ## Number of concurrent requests that a single replica can serve for ingesting data.
       ## Subsequent requests will be put in a queue.
       ## If you increase the request limit, you may need to increase "resources.requests.memory" proportionally.
-      ## Should be configured to the same value as "ingestion.s3StreamPool.maximumPooledStreams".
+      ## Should be configured to the same value as "ingestion.streamPool.maximumPooledStreams".
       ##
       requestsLimit: &dataFrameIngestionRateLimit 20
       ## Size of the queue for concurrent requests. If a request arrives to a pod with a full queue,
@@ -694,50 +674,6 @@ dataframeservice:
   ## limit, which should be set to the same value.
   ## Accepts units in "MiB" (Mebibytes, 1024 KiB) or in "MB" (Megabytes, 1000 KB)
   requestBodySizeLimit: 256MiB
-
-  ## The configuration for storing data table rows.
-  ##
-  storage:
-    ## The storage backend to use: "azure" or "s3". Defaults to s3.
-    ## azure: Azure Blob Storage. Additional configuration is required.
-    ##        Reference Azure/azure-supplemental-values.yaml.
-    ## s3: AWS S3 (or compatible backend such as MinIO). Additional configuration is required.
-    ##     See the "s3" section.
-    ##
-    type: s3
-
-    ## The configuration for the S3 backend. This configuration is only applicable when the
-    ## storage.type value is set to "s3".
-    ##
-    s3:
-      auth:
-        ## The name of the secret containing the S3 login credentials.
-        ##
-        secretName: "nidataframe-s3-credentials"
-      ## The name of the S3 bucket that the service should connect to.
-      ##
-      bucket: &dataframeBucket "systemlink-dataframe"
-      ## The scheme name. The name should not contain the following special characters: '://.'
-      ##
-      schemeName: *s3Scheme
-      ## Set this value to connect to an external S3 instance.
-      ##
-      host: *s3Host
-      ## Set this value to connect to an S3 instance that is internal to the cluster. The system
-      ## ignores this value if there is a host value.
-      ##
-      service: *s3ServiceName
-      ## S3 port number.
-      ##
-      port: *s3Port
-      ## Maximum number of concurrent connections to S3 per replica.
-      ##
-      maximumConnections: 32
-      ## S3 Region
-      ## <ATTENTION> You must set this value to the same region as the S3 instance to successfully
-      ## establish a connection.
-      ##
-      region: *s3Region
 
   ## Configure nessie.
   ##
@@ -815,38 +751,7 @@ dataframeservice:
       ## The name of the key in the above secret whose value contains the Dremio password
       ##
       passwordKey: "password"
-    distStorage:
-      # Dremio distributed storage configuration. This must be configured for the service to perform acceptably.
-      # See https://github.com/dremio/dremio-cloud-tools/blob/master/charts/dremio_v2/docs/Values-Reference.md#distributed-storage-values
-      # <ATTENTION>: This only partially configures distributed storage. Credentials must be configured in systemlink-secrets.yaml under
-      # sldremio.distStorage.aws.credentials or Azure/azure-secrets.yaml under sldremio.distStorage.azureStorage.credentials.
-      type: "aws"
-      aws:
-        bucketName: *dataframeBucket
-        path: "/dremio/distStorage"
-        authentication: "accessKeySecret"
-        # extraProperties are only necessary if not using Amazon S3
-        # <ATTENTION>: If using MinIO or an equivalent, set fs.s3a.endpoint to the FQDN of MinIO or the equivalent service.
-        # extraProperties: |
-        #   <property>
-        #     <name>fs.s3a.endpoint</name>
-        #     <value><ATTENTION> - set to the FQDN of the S3 endpoint, including the port, but without an HTTP or HTTPS prefix. Example: {svc-name}.{namespace}.svc.cluster.local:9000</value>
-        #   </property>
-        #   <property>
-        #     <name>fs.s3a.path.style.access</name>
-        #     <description>Value has to be set to true.</description>
-        #     <value>true</value>
-        #   </property>
-        #   <property>
-        #     <name>dremio.s3.compat</name>
-        #     <description>Value has to be set to true.</description>
-        #     <value>true</value>
-        #   </property>
-        #   <property>
-        #     <name>fs.s3a.connection.ssl.enabled</name>
-        #     <description>Value can either be true or false, set to true to use SSL with a secure Minio server.</description>
-        #     <value>false</value>
-        #   </property>
+
 
 ## Salt configuration.
 ##
@@ -861,36 +766,6 @@ saltmaster:
 ## Feed configuration.
 ##
 feedservice:
-  ## Configures file storage settings.
-  ##
-  storage:
-    ## Specifies which storage to use. Supports "S3".
-    ##
-    type: "s3"
-    ## Configures S3 access.
-    ##
-    s3:
-      ## Secret name for S3 credentials.
-      ##
-      secretName: "feeds-s3-credentials"
-      ## The name of an S3 bucket. The service will connect to this bucket.
-      ##
-      bucket: "systemlink-feeds"
-      ## S3 connection scheme.
-      ##
-      scheme: *s3Scheme
-      ## Set this value to connect to an external S3 instance.
-      ##
-      host: *s3Host
-      ## Set this value to connect to an internal S3 instance from the cluster. The feedservice ignores the value if the host is set.
-      ##
-      service: *s3ServiceName
-      ## S3 Port
-      ##
-      port: *s3Port
-      ## S3 Region
-      ##
-      region: *s3Region
   ## Proxy configuration to be used when the service needs to go through a proxy to have access to external services like ni.com.
   httpProxy:
     ## @param httpProxy.address Address of the HTTP proxy in the $host:$port format. Example: "1.1.1.1:2222"
@@ -920,34 +795,6 @@ fileingestion:
       nginx.ingress.kubernetes.io/proxy-request-buffering: "off"
       nginx.ingress.kubernetes.io/proxy-buffering: "off"
 
-  storage:
-    type: "s3"
-    ## Configures S3 access.
-    s3:
-      ## Secret name for S3 credentials.
-      ##
-      secretName: "fileingestion-s3-credentials"
-      ## The name of the S3 bucket that the service should connect to.
-      ##
-      bucket: "systemlink-file-ingestion"
-      ## Set this to true to limit each user to a maximum of 1Gb of file storage.
-      ##
-      storageLimitsEnabled: false
-      ## S3 connection scheme.
-      ##
-      scheme: *s3Scheme
-      ## Set this value to connect to an external S3 instance.
-      ##
-      host: *s3Host
-      ## Set this value to connect to an S3 instance which is internal to the cluster. Ignored if host is set.
-      ##
-      service: *s3ServiceName
-      ## S3 Port
-      ##
-      port: *s3Port
-      ## S3 Region
-      ##
-      region: *s3Region
   ## Configure rate limiting. Limits are enforced per-user.  Each replica of the file ingestion service
   ## applies its own per-user limit. With load-balancing, the effective rate will be higher than the
   ## individual rates configured here.
@@ -1046,36 +893,7 @@ argoworkflows:
 ##
 nbexecservice:
   maxNumberOfWorkflowsToSchedule: *workflowParallelism
-  ## Configures file storage settings.
-  ##
-  storage: 
-    ## Set this value to specify the storage type. The NbExecService supports "S3".
-    ##
-    type: "s3"
-    ## Configures S3 access.
-    ##
-    s3:
-      ## Secret name for S3 credentials.
-      ##
-      secretName: "nbexecservice-s3-credentials"
-      ## The name of the S3 bucket that the service should connect to.
-      ##
-      bucket: "systemlink-executions"
-      ## S3 connection scheme.
-      ##
-      scheme: *s3Scheme
-      ## Set this value to connect to an external S3 instance.
-      ##
-      host: *s3Host
-      ## Set this value to connect to an S3 instance that is internal to the cluster. The NbExecService ignores the value if the host is set.
-      ##
-      service: *s3ServiceName
-      ## S3 Port
-      ##
-      port: *s3Port
-      ## S3 Region
-      ##
-      region: *s3Region
+
   ## Uncomment this section to adjust the resource allocation for the notebook execution pods.
   ##
   # argo:


### PR DESCRIPTION
- [X] This contribution adheres to
      [CONTRIBUTING.md](https://github.com/ni/install-systemlink-enterprise/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Removes values related to S3 configuration from systemlink-values.yaml and systemlink-secrets.yaml and adds them to AWS/aws_supplemental_values.yml, AWS/aws-secrets.yaml, OnPrem/storage-values.yaml, and OnPrem/storage-secrets.yaml.

I intend to rename aws_supplemental_values.yml to aws-supplemental-values.yaml for consistency in a follow-up PR.

### Why should this Pull Request be merged?

Now that we support Azure Storage, it's confusing to have ATTENTION callouts for S3 in the main values files that aren't relevant when using Azure. Having separate values files to help select between storage backends keeps things organized and easier to reason about.

### What testing has been done?

Ran `helm template` with various combinations of the template files and verified the DFS configuration looked correct. I was able to install the DFS helm.dev chart to minikube using the OnPrem templates.
