### PR TITLE
Udpate default sizing for tags

### DIFF
--- a/getting-started/templates/pilot-sizing.yaml
+++ b/getting-started/templates/pilot-sizing.yaml
@@ -606,19 +606,13 @@ systemsui:
     targetMemoryUtilizationPercentage: 90
 
 tags:
+  replicaCount: 1
   resources:
     requests:
-      memory: "256Mi"
-      cpu: 100m
-    limits:
       memory: "512Mi"
-
-  autoscaling:
-    enabled: true
-    minReplicas: 2
-    maxReplicas: 2
-    targetCPUUtilizationPercentage: 60
-    targetMemoryUtilizationPercentage: 70
+      cpu: 500m
+    limits:
+      memory: "1Gi"
 
 taghistorian:
   resources:

--- a/getting-started/templates/sizing-examples/systems-sizing-example.yaml
+++ b/getting-started/templates/sizing-examples/systems-sizing-example.yaml
@@ -358,12 +358,12 @@ tags:
     limits:
       memory: 8Gi
 
-  ## @param replicaCount Number of pod replicas to deploy.
+  ## @param replicaCount Number of pod replicas to deploy. It is recommended to use an odd number.
   ## This service does not have auto-scaling. Workload and tag data will be distributed across the replicas based on the number of workspaces. 
   ## <ATTENTION> - Environments with high workspace cardinality and more than 160k Tags may require more replicas to balance the load. 
   ## Set this value according to the needs of your environment.
   ##
-  replicaCount: 2
+  replicaCount: 3
 
   ## Tag event processor containers monitor trigger conditions for tag alarms
   tagEventProcessor:

--- a/getting-started/templates/sizing-examples/systems-sizing-example.yaml
+++ b/getting-started/templates/sizing-examples/systems-sizing-example.yaml
@@ -360,7 +360,7 @@ tags:
 
   ## @param replicaCount Number of pod replicas to deploy. It is recommended to use an odd number.
   ## This service does not have auto-scaling. Workload and tag data will be distributed across the replicas based on the number of workspaces. 
-  ## <ATTENTION> - Environments with high workspace cardinality and more than 160k Tags may require more replicas to balance the load. 
+  ## <ATTENTION> - Environments with high workspace cardinality and more than 240k Tags may require more replicas to balance the load. 
   ## Set this value according to the needs of your environment.
   ##
   replicaCount: 3

--- a/getting-started/templates/sizing-examples/systems-sizing-example.yaml
+++ b/getting-started/templates/sizing-examples/systems-sizing-example.yaml
@@ -358,10 +358,10 @@ tags:
     limits:
       memory: 8Gi
 
-  ## @param replicaCount Number of pod replicas to deploy. It is recommended to use an odd number.
-  ## This service does not have auto-scaling. Workload and tag data will be distributed across the replicas based on the number of workspaces. 
-  ## <ATTENTION> - Environments with high workspace cardinality and more than 240k Tags may require more replicas to balance the load. 
-  ## Set this value according to the needs of your environment.
+  ## @param The replicaCount parameter represents the number of pod replicas to deploy to the system.
+  ## Set the parameter value according to the needs of your environment. NI recommends using an odd value.
+  ## This service does not include auto-scaling. Based on the number of workspaces, the service distributes the workload and tag data across the replicas.
+  ## <ATTENTION> Environments with high workspace cardinality and more than 240k tags might require more replicas to balance the load.
   ##
   replicaCount: 3
 

--- a/getting-started/templates/sizing-examples/systems-sizing-example.yaml
+++ b/getting-started/templates/sizing-examples/systems-sizing-example.yaml
@@ -360,7 +360,7 @@ tags:
 
   ## @param replicaCount Number of pod replicas to deploy.
   ## This service does not have auto-scaling. Workload and tag data will be distributed across the replicas based on the number of workspaces. 
-  ## Note: Environments with high workspace cardinality and more than 160k Tags may require more replicas to balance the load. 
+  ## <ATTENTION> - Environments with high workspace cardinality and more than 160k Tags may require more replicas to balance the load. 
   ## Set this value according to the needs of your environment.
   ##
   replicaCount: 2

--- a/getting-started/templates/sizing-examples/systems-sizing-example.yaml
+++ b/getting-started/templates/sizing-examples/systems-sizing-example.yaml
@@ -358,9 +358,12 @@ tags:
     limits:
       memory: 8Gi
 
-  ## @param tags.replicaCount Number of pod replicas to deploy.
-  ## This service does not have auto-scaling. Set this value according to the needs of your environment.
-  replicaCount: 1
+  ## @param replicaCount Number of pod replicas to deploy.
+  ## This service does not have auto-scaling. Workload and tag data will be distributed across the replicas based on the number of workspaces. 
+  ## Note: Environments with high workspace cardinality and more than 160k Tags may require more replicas to balance the load. 
+  ## Set this value according to the needs of your environment.
+  ##
+  replicaCount: 2
 
   ## Tag event processor containers monitor trigger conditions for tag alarms
   tagEventProcessor:


### PR DESCRIPTION
- [x] This contribution adheres to
      [CONTRIBUTING.md](https://github.com/ni/install-systemlink-enterprise/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Based on the performance testing for tags, we noticed that scaling tags to 2 pods will significantly improve the performance and load the service can handle. 

### Why should this Pull Request be merged?

The default sizing for Tags will fit a larger Tag dataset and the service will have a better performance overall.

### What testing has been done?

Performance testing
