### PR TITLE
Remove the storage.s3.service value from all sample configurations

### DIFF
--- a/getting-started/templates/AWS/aws-secrets.yaml
+++ b/getting-started/templates/AWS/aws-secrets.yaml
@@ -44,6 +44,13 @@ fileingestion:
       accessKey: *s3Password
       defaultRegion: *s3DefaultRegion
 
+fileingestioncdc:
+  secrets:
+    s3:
+      accessKeyId: *s3User
+      accessKey: *s3Password
+      defaultRegion: *s3DefaultRegion
+
 nbexecservice:
   secrets:
     s3:

--- a/getting-started/templates/AWS/aws-supplemental-values.yaml
+++ b/getting-started/templates/AWS/aws-supplemental-values.yaml
@@ -161,6 +161,16 @@ fileingestion:
       port: *s3Port
       region: *s3Region
 
+fileingestioncdc:
+  highAvailability:
+    storage:
+      type: "s3"
+      s3:
+        ## The name of the S3 bucket that the service should connect to.
+        bucket: "systemlink-flink"
+        host: *s3Host
+        region: *s3Region
+
 saltmaster:
   serviceTCP:
     type: NodePort

--- a/getting-started/templates/OnPrem/storage-secrets.yaml
+++ b/getting-started/templates/OnPrem/storage-secrets.yaml
@@ -44,6 +44,13 @@ fileingestion:
       accessKey: *s3Password
       defaultRegion: *s3DefaultRegion
 
+fileingestioncdc:
+  secrets:
+    s3:
+      accessKeyId: *s3User
+      accessKey: *s3Password
+      defaultRegion: *s3DefaultRegion
+
 nbexecservice:
   secrets:
     s3:

--- a/getting-started/templates/OnPrem/storage-values.yaml
+++ b/getting-started/templates/OnPrem/storage-values.yaml
@@ -11,14 +11,9 @@
 ## be overridden with custom values if required.
 
 ## Hostname of an external S3 provider.
-# <ATTENTION> To connect to an external S3 provider, set s3Host, s3Scheme, s3Port and s3Region.
+# <ATTENTION> To connect to an S3 provider, set s3Host, s3Scheme, s3Port and s3Region.
 ##
 s3Host: &s3Host ""
-## Service name of an in-cluster S3 provider.
-# <ATTENTION> To connect to an S3 provider within the same cluster, set s3ServiceName, s3Scheme,
-#             s3Port and s3Region, and set s3Host to an empty string.
-##
-s3ServiceName: &s3ServiceName ""
 ## Scheme used to access the configured S3 provider ("http" or "https")
 ##
 s3Scheme: &s3Scheme "https"
@@ -41,7 +36,6 @@ dataframeservice:
       maximumConnections: 32
       schemeName: *s3Scheme
       host: *s3Host
-      service: *s3ServiceName
       port: *s3Port
       region: *s3Region
   sldremio:
@@ -90,7 +84,6 @@ feedservice:
       bucket: "systemlink-feeds"
       scheme: *s3Scheme
       host: *s3Host
-      service: *s3ServiceName
       port: *s3Port
       region: *s3Region
 
@@ -106,9 +99,18 @@ fileingestion:
       storageLimitsEnabled: false
       scheme: *s3Scheme
       host: *s3Host
-      service: *s3ServiceName
       port: *s3Port
       region: *s3Region
+
+fileingestioncdc:
+  highAvailability:
+    storage:
+      type: "s3"
+      s3:
+        ## The name of the S3 bucket that the service should connect to.
+        bucket: "systemlink-flink"
+        host: *s3Host
+        region: *s3Region
 
 nbexecservice:
   storage:
@@ -119,6 +121,5 @@ nbexecservice:
       bucket: "systemlink-executions"
       scheme: *s3Scheme
       host: *s3Host
-      service: *s3ServiceName
       port: *s3Port
       region: *s3Region

--- a/getting-started/templates/systemlink-secrets.yaml
+++ b/getting-started/templates/systemlink-secrets.yaml
@@ -302,18 +302,6 @@ fileingestion:
 ##
 fileingestioncdc:
   secrets:
-    ## Access key information for S3 access.
-    ##
-    s3:
-      ## Access key ID for the S3 instance.
-      ##
-      accessKeyId: *s3User
-      ## Access key for the S3 instance.
-      ##
-      accessKey: *s3Password
-      ## Default region for the S3 instance.
-      ##
-      defaultRegion: *s3DefaultRegion
     ## Credentials for the MongoDB cluster.
     ##
     mongodb:

--- a/getting-started/templates/systemlink-values.yaml
+++ b/getting-started/templates/systemlink-values.yaml
@@ -795,35 +795,6 @@ fileingestion:
       nginx.ingress.kubernetes.io/proxy-request-buffering: "off"
       nginx.ingress.kubernetes.io/proxy-buffering: "off"
 
-  storage:
-    type: "s3"
-    ## Configures S3 access.
-    s3:
-      ## Secret name for S3 credentials.
-      ##
-      secretName: "fileingestion-s3-credentials"
-      ## The name of the S3 bucket that the service should connect to.
-      ##
-      bucket: "systemlink-file-ingestion"
-      ## Set this to true to limit each user to a maximum of 1Gb of file storage.
-      ##
-      storageLimitsEnabled: false
-      ## S3 connection scheme.
-      ##
-      scheme: *s3Scheme
-      ## Set this value to connect to an external S3 instance.
-      ##
-      host: *s3Host
-      ## Set this value to connect to an S3 instance which is internal to the cluster. Ignored if host is set.
-      ##
-      service: *s3ServiceName
-      ## S3 Port
-      ##
-      port: *s3Port
-      ## S3 Region
-      ##
-      region: *s3Region
-
   ## Feature toggles.
   ## 
   featureToggle:
@@ -929,31 +900,6 @@ fileingestioncdc:
     ## Whether to enable high availability. This is required for production environments.
     ## Needs an object storage medium, like S3, Azure Storage or a ReadWriteMany volume.
     enabled: true
-    ## Storage configuration
-    ##
-    storage:
-      ## The type of the object storage medium. Supported values are "s3", "azure" and "readWriteManyVolume"
-      type: "s3"
-      ## Configure S3 access.
-      # <ATTENTION> - This needs to be configured only if `highAvailability.storage.type` is `s3`
-      ##
-      s3:
-        ## Secret name for S3 credentials
-        secretName: "flink-aws-keys"
-        ## S3 access type. Supported values are "ACCESS_KEY" and "AWS_WEB_IDENTITY_TOKEN".
-        authType: "ACCESS_KEY"
-        ## The name of the S3 bucket that the service should connect to.
-        bucket: "systemlink-flink"
-        ## Set this value to connect to an external S3 instance.
-        host: "s3.amazonaws.com"
-        ## Set this value to connect to an S3 instance which is internal to the cluster.
-        service: ""
-        ## S3 Region.
-        region: "us-east-1"
-        ## The name of the key in the above secret whose value contains the S3 AccessKeyId.
-        accessKeyIdKey: "aws-access-key-id"
-        ## The name of the key in the above secret whose value contains the S3 SecretAccessKey.
-        secretAccessKeyKey: "aws-secret-access-key"
 
   ## Job configuration.
   ##


### PR DESCRIPTION
- [x] This contribution adheres to
      [CONTRIBUTING.md](https://github.com/ni/install-systemlink-enterprise/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

The "service" value is a legacy of when we included MinIO in the top-level Helm chart. It's not useful for any other storage provider. I am working on a task to remove it from all our configurations. This change removes usage of the value from all of our example templates. 

While doing this I discovered that we had a bad merge between a change to refactor storage configuration to better handle the Azure case and a change to introduce the new file indexing capabilities. Some S3 values were added in the wrong files. I have moved everything to the correct place with this change.

### Why should this Pull Request be merged?

TODO: Justify why this contribution should be part of the project.

### What testing has been done?

TODO: Detail what testing has been done to ensure this submission meets
requirements.
