### PR TITLE
Fix incorrect description for webserver.encryptionKey

### DIFF
--- a/getting-started/templates/systemlink-secrets.yaml
+++ b/getting-started/templates/systemlink-secrets.yaml
@@ -61,7 +61,7 @@ secrets:
 ##
 webserver:
   secrets:
-    ## Cryptographic key to be used for AES-128 encryption of session data. This key should have a length of 32 bytes.
+    ## Cryptographic key to be used for AES-128 encryption of session data. This key should have a length of 16 bytes.
     ##
     encryptionKey: ""  # <ATTENTION>
     ## Cryptographic key to be used for SHA-256 signing of session data. This key should have a length between 32 and 64 bytes.

--- a/getting-started/templates/systemlink-secrets.yaml
+++ b/getting-started/templates/systemlink-secrets.yaml
@@ -61,10 +61,10 @@ secrets:
 ##
 webserver:
   secrets:
-    ## Cryptographic key to be used for AES-128 encryption of session data. This key should have a length of 16 bytes.
+    ## This AES-128 key encrypts session data. Ensure the key is 16 bytes long.
     ##
     encryptionKey: ""  # <ATTENTION>
-    ## Cryptographic key to be used for SHA-256 signing of session data. This key should have a length between 32 and 64 bytes.
+    ## This SHA-256 key cryptographically signs session data. Ensure this key has a length between 32 and 64 bytes.
     ##
     signatureKey: ""  # <ATTENTION>
     ## If webserver.proxy.authority is configured, optionally provide credentials for the proxy.


### PR DESCRIPTION
- [x] This contribution adheres to
      [CONTRIBUTING.md](https://github.com/ni/install-systemlink-enterprise/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Fixes an incorrect description in a template file.

### Why should this Pull Request be merged?

Correct customer-facing documentation.

### What testing has been done?

This text is copied directly from the actual Helm chart and conforms to what we are deploying for our internal clusters. 
