### PR TITLE
Update DFS pilot sizing for Apache Arrow ingestion

### DIFF
--- a/getting-started/templates/pilot-sizing.yaml
+++ b/getting-started/templates/pilot-sizing.yaml
@@ -136,14 +136,14 @@ dataframeservice:
     targetMemoryUtilizationPercentage: 70
 
   ingestion:
-    # Configuration for ingestion requests that use the Apache Arrow format.
+    # Configuration for ingestion requests in the Apache Arrow format.
     arrow:
-      # The maximum number of bytes that the server will allocate in order to hold a single record
-      # batch while processing an ingestion request. This value must be greater than zero. For
-      # requests that don't use compression, this is compared to the size of the record batch in
-      # memory. For requests that use compression, this is compared to the size of the
-      # uncompressed record batch in memory plus the size of each compressed value buffer. Larger
-      # values require additional pod memory per request.
+      # The maximum number of bytes the server will allocate to hold each record batch during
+      # an ingestion request. This value must be greater than zero. Larger values require
+      # additional pod memory per request.
+      # For non-compressed requests, the service compares this value to the size of the record
+      # batch in memory. For compressed requests, the service compares this value to the total
+      # size of each compressed value buffer and the uncompressed record batch in memory.
       maxRecordBatchSize: 16MiB
     
     # Configuration for the pool of streams used to upload table data to storage such as S3 or

--- a/getting-started/templates/pilot-sizing.yaml
+++ b/getting-started/templates/pilot-sizing.yaml
@@ -136,6 +136,16 @@ dataframeservice:
     targetMemoryUtilizationPercentage: 70
 
   ingestion:
+    # Configuration for ingestion requests that use the Apache Arrow format.
+    arrow:
+      # The maximum number of bytes that the server will allocate in order to hold a single record
+      # batch while processing an ingestion request. This value must be greater than zero. For
+      # requests that don't use compression, this is compared to the size of the record batch in
+      # memory. For requests that use compression, this is compared to the size of the
+      # uncompressed record batch in memory plus the size of each compressed value buffer. Larger
+      # values require additional pod memory per request.
+      maxRecordBatchSize: 16MiB
+    
     # Configuration for the pool of streams used to upload table data to storage such as S3 or
     # Azure Blob Storage.
     streamPool:
@@ -151,6 +161,7 @@ dataframeservice:
       # the service in "resources.requests.memory".
       # WARNING: Setting this value 0 would leave the pool unbounded, which could cause high memory usage.
       maximumPooledStreams: 2
+    
     # Configuration for the S3 ingestion backend.
     s3Backend:
       # Approximate number of values to buffer into memory for writing to a parquet row group.

--- a/getting-started/templates/sizing-examples/data-management-sizing-example.yaml
+++ b/getting-started/templates/sizing-examples/data-management-sizing-example.yaml
@@ -37,6 +37,16 @@ dataframeservice:
 
   ## Configuration for DataFrame writes
   ingestion:
+    # Configuration for ingestion requests that use the Apache Arrow format.
+    arrow:
+      # The maximum number of bytes that the server will allocate in order to hold a single record
+      # batch while processing an ingestion request. This value must be greater than zero. For
+      # requests that don't use compression, this is compared to the size of the record batch in
+      # memory. For requests that use compression, this is compared to the size of the
+      # uncompressed record batch in memory plus the size of each compressed value buffer. Larger
+      # values require additional pod memory per request.
+      maxRecordBatchSize: 32MiB
+
     # Configuration for the pool of streams used to upload table data to storage such as S3 or
     # Azure Blob Storage.
     streamPool:

--- a/getting-started/templates/sizing-examples/data-management-sizing-example.yaml
+++ b/getting-started/templates/sizing-examples/data-management-sizing-example.yaml
@@ -37,14 +37,14 @@ dataframeservice:
 
   ## Configuration for DataFrame writes
   ingestion:
-    # Configuration for ingestion requests that use the Apache Arrow format.
+    # Configuration for ingestion requests in the Apache Arrow format.
     arrow:
-      # The maximum number of bytes that the server will allocate in order to hold a single record
-      # batch while processing an ingestion request. This value must be greater than zero. For
-      # requests that don't use compression, this is compared to the size of the record batch in
-      # memory. For requests that use compression, this is compared to the size of the
-      # uncompressed record batch in memory plus the size of each compressed value buffer. Larger
-      # values require additional pod memory per request.
+      # The maximum number of bytes the server will allocate to hold each record batch during
+      # an ingestion request. This value must be greater than zero. Larger values require
+      # additional pod memory per request.
+      # For non-compressed requests, the service compares this value to the size of the record
+      # batch in memory. For compressed requests, the service compares this value to the total
+      # size of each compressed value buffer and the uncompressed record batch in memory.
       maxRecordBatchSize: 32MiB
 
     # Configuration for the pool of streams used to upload table data to storage such as S3 or


### PR DESCRIPTION
- [X] This contribution adheres to
      [CONTRIBUTING.md](https://github.com/ni/install-systemlink-enterprise/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Update pilot sizing and example sizing with new Arrow record batch size limit. In theory, only having 2 concurrent requests at a time should allow for 32 MB record batches, even with a 512 MB memory limit, but the Arrow record batches allocate memory from the unmanaged heap. By default, the .NET garbage collector will use up to 75% of available memory. For a 512 MB memory limit, that only leaves 128 MB for the unmanaged heap. This reinforces that there isn't a straightforward formula to follow and that DFS tuning requires testing with representative workflows.

### Why should this Pull Request be merged?

Ensure the pilot sizing is stable when clients are sending data in the Apache Arrow format.

### What testing has been done?

Installed the DFS to minikube using the pilot sizing values (and an even smaller Dremio) but scaled to 1 replica. Used k6 to have 2 clients write 21,000 rows per request to a 100 column table as fast is they could for ~2.5 minutes. Each request send close to the 16 MB limit. Verified the service didn't crash. In total, they two clients sent made 606 requests, sending ~10 GB of data.