### PR TITLE
Update templates for new Dremio Helm chart

### DIFF
--- a/getting-started/templates/AWS/aws-supplemental-values.yaml
+++ b/getting-started/templates/AWS/aws-supplemental-values.yaml
@@ -110,8 +110,14 @@ dataframeservice:
     distStorage:
       type: "aws"
       aws:
-        ## The service assumes an IAM role from the EC2 instance metadata as the authentication
-        ## method for distributed storage (may require configuring "sldremio.nodeSelector").
+        ## S3 authentication method for distributed storage.
+        ## metadata: The service assumes an IAM role from the EC2 instance metadata (may require
+        ##           configuring "sldremio.nodeSelector").
+        ## podIdentity: The service assumes an IAM role via EKS pod identity. Both coordinators
+        ##              and executors must have access (service account names are configured via
+        ##              "sldremio.coordinator.serviceAccount" and "sldremio.executor.serviceAccount").
+        ##              Note that this only applies to distributed storage. DFS S3 bucket access
+        ##              from Dremio does not support pod identity.
         ##
         authentication: "metadata"
         ## The name of the S3 bucket that Dremio should use for the distributed storage cache.
@@ -142,6 +148,16 @@ dataframeservice:
         #     <description>The region where S3 storage is located (see s3Region).</description>
         #     <value>us-east-1</value>
         #   </property>
+
+    ## The name of the Dremio service accounts defined in the pod spec when creating the EKS pod
+    ## identity association for distributed storage (see "sldremio.distStorage.aws.authentication").
+    # <ATTENTION> - Optional - Uncomment and enter a name for the service accounts. Default values
+    # are specified below.
+    ##
+    # coordinator:
+    #   serviceAccount: dremio-coordinator
+    # executor:
+    #   serviceAccount: dremio-executor
 
     ## Configuration for overriding the top-level "storage" section.
     ##

--- a/getting-started/templates/pilot-sizing.yaml
+++ b/getting-started/templates/pilot-sizing.yaml
@@ -194,35 +194,58 @@ dataframeservice:
 
   sldremio:
     coordinator:
-      cpu: 2
-      memory: 16384
+      resources:
+        requests:
+          cpu: "2"
+          memory: 16Gi
+        limits:
+          memory: 16Gi
       volumeSize: "100Gi"
     executor:
       count: 1
-      cpu: 4
-      memory: 31000
+      resources:
+        requests:
+          cpu: "4"
+          memory: 29Gi
+        limits:
+          memory: 29Gi
       volumeSize: "50Gi"
       engineOverride:
         iceberg:
           count: 2
-          cpu: 4
-          memory: 16384
-          heapMemoryOverride: 10000
-          directMemoryOverride: 5000
+          resources:
+            requests:
+              cpu: "4"
+              memory: 16Gi
+            limits:
+              memory: 16Gi
+          volumeSize: "20Gi"
     zookeeper:
       count: 1
   # The above is the recommended configuration for pilot deployments.
   # For deployments where the DataFrame Service will not be used, the following
   # configuration is the bare minimum for the Dremio pods to start up:
+  # queryEngine:
+  #   workloadManagement:
+  #     enabled: false
   # sldremio:
   #   coordinator:
-  #     cpu: 1
-  #     memory: 4096
+  #     resources:
+  #       requests:
+  #         cpu: "1"
+  #         memory: 4Gi
+  #       limits:
+  #         memory: 4Gi
   #     volumeSize: "10Gi"
   #   executor:
   #     count: 1
-  #     cpu: 1
-  #     memory: 4096
+  #     engines: [default]
+  #     resources:
+  #       requests:
+  #         cpu: "1"
+  #         memory: 4Gi
+  #       limits:
+  #         memory: 4Gi
   #     volumeSize: "10Gi"
   #   zookeeper:
   #     count: 1

--- a/getting-started/templates/sizing-examples/data-management-sizing-example.yaml
+++ b/getting-started/templates/sizing-examples/data-management-sizing-example.yaml
@@ -131,37 +131,44 @@ dataframeservice:
     ## Resource requests for the coordinator. For information on resource requirements,
     ## refer to the Dremio documentation: https://docs.dremio.com/current/deploy-dremio/other-options/standalone/system-requirements#server-or-instance-hardware
     coordinator:
-      ## @param dataframeservice.sldremio.coordinator.cpu CPU allocated to each coordinator, expressed in CPU cores.
-      cpu: 3
-      ## @param dataframeservice.sldremio.coordinator.memory Memory allocated to each coordinator, expressed in MB.
-      memory: 16384
+      ## @param dataframeservice.sldremio.coordinator.resources Requests and limits for the coordinator
+      resources:
+        requests:
+          cpu: "3"
+          memory: 16Gi
+        limits:
+          memory: 16Gi
       ## @param dataframeservice.sldremio.coordinator.volumeSize Coordinator data volume size (applies to the master coordinator only).
       volumeSize: 256Gi
     ## Resource requests for the executor. For information on resource requirements,
     ## refer to the Dremio documentation: https://docs.dremio.com/current/deploy-dremio/other-options/standalone/system-requirements#server-or-instance-hardware
     executor:
-      ## @param dataframeservice.sldremio.executor.count Number of executors.
+      ## @param dataframeservice.sldremio.executor.count Number of default engine executors.
       count: 3
-      ## @param dataframeservice.sldremio.executor.cpu CPU allocated to each executor, expressed in CPU cores.
-      cpu: 15
-      ## @param dataframeservice.sldremio.executor.memory Memory allocated to each executor, expressed in MB.
-      memory: 73728
-      ## @param dataframeservice.sldremio.executor.volumeSize Executor volume size.
+      ## @param dataframeservice.sldremio.executor.resources Requests and limits for the default engine executors
+      resources:
+        requests:
+          cpu: "15"
+          memory: 72Gi
+        limits:
+          memory: 72Gi
+      ## @param dataframeservice.sldremio.executor.volumeSize Default engine executor volume size.
       volumeSize: 256Gi
       ## Override configuration for the Iceberg executors. This will create a separate group of Iceberg executors
       ## in parallel with the standard executors. Standard executors process queries, while iceberg executors process writes.
       engineOverride:
         iceberg:
-          ## @param dataframeservice.sldremio.executor.engineOverride.iceberg.count Number of executors.
+          ## @param dataframeservice.sldremio.executor.engineOverride.iceberg.count Number of Iceberg engine executors.
           count: 4
-          ## @param dataframeservice.sldremio.executor.engineOverride.iceberg.cpu CPU allocated to each executor, expressed in CPU cores.
-          cpu: 9
-          ## @param dataframeservice.sldremio.executor.engineOverride.iceberg.memory Memory allocated to each executor, expressed in MB.
-          memory: 32768
-          ## @param dataframeservice.sldremio.executor.engineOverride.iceberg.heapMemoryOverride Configures the heap memory pool for the executor.
-          heapMemoryOverride: 20000
-          ## @param dataframeservice.sldremio.executor.engineOverride.iceberg.directMemoryOverride Configures the direct memory pool for the executor.
-          directMemoryOverride: 10000
+          ## @param dataframeservice.sldremio.executor.engineOverride.iceberg.resources Requests and limits for the Iceberg engine executors.
+          resources:
+            requests:
+              cpu: "9"
+              memory: 32Gi
+            limits:
+              memory: 32Gi
+          ## @param dataframeservice.sldremio.executor.engineOverride.iceberg.volumeSize Iceberg engine executor volume size.
+          volumeSize: 20Gi
 
   ## Workload configuration
   workloadManagement:

--- a/getting-started/templates/sizing-examples/dataframe-service/dfs1-values.yaml
+++ b/getting-started/templates/sizing-examples/dataframe-service/dfs1-values.yaml
@@ -22,22 +22,29 @@ dataframeservice:
 
   sldremio:
     coordinator:
-      cpu: 2
-      memory: 16384
+      resources:
+        requests:
+          cpu: "2"
+          memory: 16Gi
+        limits:
+          memory: 16Gi
       volumeSize: 100Gi
     executor:
       count: 3
-      cpu: 14
-      memory: 16384
+      resources:
+        requests:
+          cpu: "14"
+          memory: 16Gi
+        limits:
+          memory: 16Gi
       volumeSize: 256Gi
-      engines:
-        - default
-        - iceberg
       engineOverride:
         iceberg:
           count: 2
-          cpu: 4
-          memory: 16384
-          heapMemoryOverride: 10000
-          directMemoryOverride: 5000
+          resources:
+            requests:
+              cpu: "4"
+              memory: 16Gi
+            limits:
+              memory: 16Gi
           volumeSize: 20Gi

--- a/getting-started/templates/sizing-examples/dataframe-service/dfs3-values.yaml
+++ b/getting-started/templates/sizing-examples/dataframe-service/dfs3-values.yaml
@@ -23,22 +23,29 @@ dataframeservice:
 
   sldremio:
     coordinator:
-      cpu: 4
-      memory: 16384
+      resources:
+        requests:
+          cpu: "4"
+          memory: 16Gi
+        limits:
+          memory: 16Gi
       volumeSize: 150Gi
     executor:
       count: 10
-      cpu: 22
-      memory: 122800
+      resources:
+        requests:
+          cpu: "22"
+          memory: 115Gi
+        limits:
+          memory: 115Gi
       volumeSize: 400Gi
-      engines:
-        - default
-        - iceberg
       engineOverride:
         iceberg:
           count: 5
-          cpu: 22
-          memory: 68719
-          heapMemoryOverride: 40000
-          directMemoryOverride: 20000
+          resources:
+            requests:
+              cpu: "22"
+              memory: 64Gi
+            limits:
+              memory: 64Gi
           volumeSize: 20Gi

--- a/getting-started/templates/systemlink-values.yaml
+++ b/getting-started/templates/systemlink-values.yaml
@@ -836,30 +836,41 @@ dataframeservice:
     ## You may also refer to the the data management sizing example on GitHub: https://github.com/ni/install-systemlink-enterprise/blob/main/getting-started/templates/sizing-examples/data-management-sizing-example.yaml.
     ##
     # coordinator:
-    #   cpu: 3
-    #   memory: 16384
+    #   resources:
+    #     requests:
+    #       cpu: "3"
+    #       memory: 16Gi
+    #     limits:
+    #       memory: 16Gi
     #   volumeSize: 256Gi
     # executor:
     #   count: 3
-    #   cpu: 15
-    #   memory: 73728
+    #   resources:
+    #     requests:
+    #       cpu: "15"
+    #       memory: 72Gi
+    #     limits:
+    #       memory: 72Gi
     #   volumeSize: 256Gi
-    # engines:
-    #   - default
-    #   - iceberg
     # engineOverride:
     #   iceberg:
     #     count: 4
-    #     cpu: 9
-    #     memory: 32768
-    #     heapMemoryOverride: 20000
-    #     directMemoryOverride: 10000
-    ## CPU and memory allocated to each zookeeper pod, expressed in CPU cores and MB respectively.
-    ## Count should correspond with the number of nodes that received the "high.mem" label.
+    #     resources:
+    #       requests:
+    #         cpu: "9"
+    #         memory: 32Gi
+    #       limits:
+    #         memory: 32Gi
+    #     volumeSize: 20Gi
+    # # Count should correspond with the number of nodes that received the "dremio" label.
     # zookeeper:
-    #   cpu: 0.5
-    #   memory: 1024
     #   count: 3
+    #   resources:
+    #     requests:
+    #       cpu: "500m"
+    #       memory: 1Gi
+    #     limits:
+    #       memory: 1Gi
     auth:
       ## Name of the secret containing the Dremio login credentials
       ##


### PR DESCRIPTION
- [X] This contribution adheres to
      [CONTRIBUTING.md](https://github.com/ni/install-systemlink-enterprise/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Updates Helm templates to specify Dremio resources via requests and limits instead of separate `cpu` and `memory` values. Old memory values were in units of M (1,000,000 bytes). New memory values must be whole numbers with `Mi`, `Gi`, or `Ti` units.

### Why should this Pull Request be merged?

This is required for the new Dremio Helm chart included in 2026-05 (will be documented in the release notes).

### What testing has been done?

Ran `helm template` with each of the modified templates.