### PR TITLE
[2026-06] Add toggles for disabling Python 3.13's VERIFY_X509_STRICT for jupyter/nbexec

### DIFF
--- a/getting-started/templates/systemlink-values.yaml
+++ b/getting-started/templates/systemlink-values.yaml
@@ -1069,6 +1069,11 @@ sl-jupyterhub:
         ## Setting this to "true" will enable the legacy implementation of Jupyter usernames.
         JUPYTER_USERNAME_AS_SYSTEMLINK_USER_ID: "false"
     singleuser:
+      extraEnv:
+        ## Temporarily disable Python 3.13's VERIFY_X509_STRICT enforcement, which rejects root CAs
+        ## lacking a required keyUsage extension. Set to "false" after regenerating the CA to be compliant.
+        # <ATTENTION> - This toggle will be removed in a future release.
+        DISABLE_VERIFY_X509_STRICT: "true"
       networkPolicy:
         egressAllowRules:
           # <ATTENTION> - Set to true to enable JupyterHub user pods to establish outbound connections to private IP addresses.
@@ -1115,6 +1120,13 @@ argoworkflows:
 ##
 nbexecservice:
   maxNumberOfWorkflowsToSchedule: *workflowParallelism
+
+  ## Temporarily disable Python 3.13's VERIFY_X509_STRICT enforcement, which rejects root CAs
+  ## lacking a required keyUsage extension. Set to false after regenerating the CA to be compliant.
+  # <ATTENTION> - This toggle will be removed in a future release.
+  argo:
+    workflow:
+      disableVerifyX509Strict: true
 
   ## Uncomment this section to adjust the resource allocation for the notebook execution pods.
   ##


### PR DESCRIPTION
- [X] This contribution adheres to
      [CONTRIBUTING.md](https://github.com/ni/install-systemlink-enterprise/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Document toggles for disabling Python 3.13's VERIFY_X509_STRICT in jupyter/nbexec.

### Why should this Pull Request be merged?

Document the value.

### What testing has been done?

The toggle was tested on internal SLE clusters.