### PR TITLE
systemlink-values template: adding dataframeservice.enabled to toggle Grafana dashboard plugin and security privilege display

### DIFF
--- a/getting-started/templates/systemlink-values.yaml
+++ b/getting-started/templates/systemlink-values.yaml
@@ -1413,7 +1413,7 @@ serviceregistry:
         enabled: *specificationManagementEnabled
   privilegeToggles:
     ## Show or hide the option to set security privileges for data frame service
-    dataframe: true
+    dataframe: *dataframeserviceEnabled
 
 ## Configuration for dynamic form fields.
 ##

--- a/getting-started/templates/systemlink-values.yaml
+++ b/getting-started/templates/systemlink-values.yaml
@@ -1411,6 +1411,9 @@ serviceregistry:
       specification:
         ## Add the "Specification" service to the service registry if enabled
         enabled: *specificationManagementEnabled
+  privilegeToggles:
+    ## Show or hide the option to set security privileges for data frame service
+    dataframe: true
 
 ## Configuration for dynamic form fields.
 ##

--- a/getting-started/templates/systemlink-values.yaml
+++ b/getting-started/templates/systemlink-values.yaml
@@ -671,7 +671,7 @@ dashboardhost:
 
 ## Grafana provisioning
 ##
-# grafanaprovisioning:
+grafanaprovisioning:
   # grafanaDashboardsProvisioning:
     ## Dashboards listed are enumerated over the dashboard-configmap-template.yaml
     ## Each key under the "dashboards" item will be the name of a ConfigMap.
@@ -690,12 +690,12 @@ dashboardhost:
       #     some-dashboard:
       #      path: "dashboards/project/some-dashboard.json"
       #      enabled: false | true
-  # grafanaDatasourcesProvisioning:
+  grafanaDatasourcesProvisioning:
     ## SystemLink enumerates all datasources in the datasource-configmap-template.yaml file.
     ## Each key under the "datasources" item will be the name of a datasource in the ConfigMap.
     ## By default, all "enabled" parameters are considered as true even if they are not mentioned. You can disable this by assigning "whitelistMode: true"
     # whitelistMode: false
-    # projects:
+    projects:
       ## Datasources must be grouped under projects
       ## There is an optional "enabled" parameter that defaults to true which can be used to toggle the project/dashboard on or off.
       # some-project:
@@ -707,6 +707,14 @@ dashboardhost:
       #       type: some-datasource
       #       ## SystemLink copies each data source exactly as written into the template. To properly define an entry into the template, refer to the format as defined in the following link: https://github.com/grafana/helm-charts/blob/307aae1ba29039c4c80581d457299c0a126b55c1/charts/grafana/values.yaml#L458
       #       ## Instead of a list of data sources, SystemLink uses key-pair values. You can define these values in the same way as Grafana.
+      systemlink:
+        datasources:
+          ni-sldataframe-datasource:
+            enabled: *dataframeserviceEnabled
+          ni-slworkorders-datasource:
+            enabled: *workitemEnabled
+          ni-sltestplans-datasource:
+            enabled: *workitemEnabled
 
 ## Configuration for the Data Frame service.
 ##

--- a/getting-started/templates/systemlink-values.yaml
+++ b/getting-started/templates/systemlink-values.yaml
@@ -711,6 +711,10 @@ dashboardhost:
 ## Configuration for the Data Frame service.
 ##
 dataframeservice:
+  ## Set true to enable the deployment of the DataFrame service.
+  ## By default, this is enabled and the DataFrame service is deployed.
+  enabled: &dataframeserviceEnabled true
+
   ## Ingress configuration
   ##
   ingress:

--- a/getting-started/templates/systemlink-values.yaml
+++ b/getting-started/templates/systemlink-values.yaml
@@ -669,52 +669,13 @@ dashboardhost:
         ##
         # allow_loading_unsigned_plugins: ni-systemlink-app
 
-## Grafana provisioning
+## Configuration for work item service.
 ##
-grafanaprovisioning:
-  # grafanaDashboardsProvisioning:
-    ## Dashboards listed are enumerated over the dashboard-configmap-template.yaml
-    ## Each key under the "dashboards" item will be the name of a ConfigMap.
-    ## NI recommends adding the "-dashboard" suffix to each key to avoid a name collision with other ConfigMaps.
-    ## You can place all Dashboard JSON files under the "dashboards/[project-name]/" file path.
-    ## By default, SystemLink considers all enabled parameters as 'true', even if a parameter is not in the JSON file. You can disable this setting by assigning the "whitelistMode" value to 'true'.
-    ##
-    # whitelistMode: false
-    # projects:
-      ## You must group all dashboards under a project.
-      ## The "path" of a dashboard must point to a JSON file.
-      ## Use the "enabled" parameter to toggle a project or dashboard on or off. This optional parameter defaults to 'true'.
-      # some-project:
-      #   enabled: false | true
-      #   dashboards:
-      #     some-dashboard:
-      #      path: "dashboards/project/some-dashboard.json"
-      #      enabled: false | true
-  grafanaDatasourcesProvisioning:
-    ## SystemLink enumerates all datasources in the datasource-configmap-template.yaml file.
-    ## Each key under the "datasources" item will be the name of a datasource in the ConfigMap.
-    ## By default, all "enabled" parameters are considered as true even if they are not mentioned. You can disable this by assigning "whitelistMode: true"
-    # whitelistMode: false
-    projects:
-      ## Datasources must be grouped under projects
-      ## There is an optional "enabled" parameter that defaults to true which can be used to toggle the project/dashboard on or off.
-      # some-project:
-      #   enabled: false | true
-      #   datasources:
-      #     some-datasource:
-      #       enabled: false | true
-      #       name: Some Datasource
-      #       type: some-datasource
-      #       ## SystemLink copies each data source exactly as written into the template. To properly define an entry into the template, refer to the format as defined in the following link: https://github.com/grafana/helm-charts/blob/307aae1ba29039c4c80581d457299c0a126b55c1/charts/grafana/values.yaml#L458
-      #       ## Instead of a list of data sources, SystemLink uses key-pair values. You can define these values in the same way as Grafana.
-      systemlink:
-        datasources:
-          ni-sldataframe-datasource:
-            enabled: *dataframeserviceEnabled
-          ni-slworkorders-datasource:
-            enabled: *workitemEnabled
-          ni-sltestplans-datasource:
-            enabled: *workitemEnabled
+workitem:
+  ## <ATTENTION> - Set false to disable the deployment of the work item and lab management UI services.
+  ## By default, this is enabled and the work item and lab management UI services are deployed.
+  ##
+  enabled: &workitemEnabled true
 
 ## Configuration for the Data Frame service.
 ##
@@ -922,6 +883,53 @@ dataframeservice:
       # - SupportsAppend
       # - MetadataModifiedAt
       # - MetadataRevision
+
+## Grafana provisioning
+##
+grafanaprovisioning:
+  # grafanaDashboardsProvisioning:
+    ## Dashboards listed are enumerated over the dashboard-configmap-template.yaml
+    ## Each key under the "dashboards" item will be the name of a ConfigMap.
+    ## NI recommends adding the "-dashboard" suffix to each key to avoid a name collision with other ConfigMaps.
+    ## You can place all Dashboard JSON files under the "dashboards/[project-name]/" file path.
+    ## By default, SystemLink considers all enabled parameters as 'true', even if a parameter is not in the JSON file. You can disable this setting by assigning the "whitelistMode" value to 'true'.
+    ##
+    # whitelistMode: false
+    # projects:
+      ## You must group all dashboards under a project.
+      ## The "path" of a dashboard must point to a JSON file.
+      ## Use the "enabled" parameter to toggle a project or dashboard on or off. This optional parameter defaults to 'true'.
+      # some-project:
+      #   enabled: false | true
+      #   dashboards:
+      #     some-dashboard:
+      #      path: "dashboards/project/some-dashboard.json"
+      #      enabled: false | true
+  grafanaDatasourcesProvisioning:
+    ## SystemLink enumerates all datasources in the datasource-configmap-template.yaml file.
+    ## Each key under the "datasources" item will be the name of a datasource in the ConfigMap.
+    ## By default, all "enabled" parameters are considered as true even if they are not mentioned. You can disable this by assigning "whitelistMode: true"
+    # whitelistMode: false
+    projects:
+      ## Datasources must be grouped under projects
+      ## There is an optional "enabled" parameter that defaults to true which can be used to toggle the project/dashboard on or off.
+      # some-project:
+      #   enabled: false | true
+      #   datasources:
+      #     some-datasource:
+      #       enabled: false | true
+      #       name: Some Datasource
+      #       type: some-datasource
+      #       ## SystemLink copies each data source exactly as written into the template. To properly define an entry into the template, refer to the format as defined in the following link: https://github.com/grafana/helm-charts/blob/307aae1ba29039c4c80581d457299c0a126b55c1/charts/grafana/values.yaml#L458
+      #       ## Instead of a list of data sources, SystemLink uses key-pair values. You can define these values in the same way as Grafana.
+      systemlink:
+        datasources:
+          ni-sldataframe-datasource:
+            enabled: *dataframeserviceEnabled
+          ni-slworkorders-datasource:
+            enabled: *workitemEnabled
+          ni-sltestplans-datasource:
+            enabled: *workitemEnabled
 
 ## Salt configuration.
 ##
@@ -1369,14 +1377,6 @@ comments:
   ## Maximum number of comments supported per delete comments request.
   ##
   maximumCommentsPerDeleteRequest: 1000
-
-## Configuration for work item service.
-##
-workitem:
-  ## <ATTENTION> - Set false to disable the deployment of the work item and lab management UI services.
-  ## By default, this is enabled and the work item and lab management UI services are deployed.
-  ##
-  enabled: &workitemEnabled true
 
 ## Configuration for specification management service.
 ##

--- a/getting-started/templates/systemlink-values.yaml
+++ b/getting-started/templates/systemlink-values.yaml
@@ -1368,7 +1368,7 @@ workitem:
   ## <ATTENTION> - Set false to disable the deployment of the work item and lab management UI services.
   ## By default, this is enabled and the work item and lab management UI services are deployed.
   ##
-  enabled: true
+  enabled: &workitemEnabled true
 
 ## Configuration for specification management service.
 ##


### PR DESCRIPTION
- [x] This contribution adheres to
      [CONTRIBUTING.md](https://github.com/ni/install-systemlink-enterprise/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

We've added code in SLE to make the Grafana DataFrame plugin depend on dataframeservice being enabled. We also hide the ability to edit security privileges for dataframe roles when dataframe is disabled.

Additional notes:
* I had to move some of the settings around so that `workitemEnabled` and `dataframeEnabled` were defined by the time they were used.
* I've also added the code to hide the work orders and test plans grafana plugins if work item service is disabled.

### Why should this Pull Request be merged?

To make sure those using the systemlink-values template don't miss this setting. See [AB#3916389](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/3916389).

### What testing has been done?

Testing was done as part of the original AzDO PR.