### PR TITLE
Introduce global featureFlags configuration for Work Item and Work Order APIs

### DIFF
--- a/getting-started/templates/sizing-examples/data-management-sizing-example.yaml
+++ b/getting-started/templates/sizing-examples/data-management-sizing-example.yaml
@@ -301,14 +301,6 @@ workitem:
     targetCPUUtilizationPercentage: 60
     targetMemoryUtilizationPercentage: 80
 
-  ## @param workitem.maximumWorkOrdersPerCreateRequest Maximum number of work orders per create work orders request.
-  maximumWorkOrdersPerCreateRequest: 1000
-  ## @param workitem.maximumTakePerQueryWorkOrdersRequest Maximum query take per query work orders request.
-  maximumTakePerQueryWorkOrdersRequest: 1000
-  ## @param workitem.maximumWorkOrdersPerUpdateRequest Maximum number of work orders per update work orders request.
-  maximumWorkOrdersPerUpdateRequest: 1000
-  ## @param workitem.maximumWorkOrdersPerDeleteRequest Maximum number of work orders per delete work orders request.
-  maximumWorkOrdersPerDeleteRequest: 1000
   ## @param workitem.maximumWorkItemsPerCreateRequest Maximum number of work items per create work items request.
   maximumWorkItemsPerCreateRequest: 1000
   ## @param workitem.maximumTakePerQueryWorkItemsRequest Maximum query take per query work items request.

--- a/getting-started/templates/systemlink-values.yaml
+++ b/getting-started/templates/systemlink-values.yaml
@@ -697,25 +697,33 @@ dashboardhost:
       ## You must group all dashboards under a project.
       ## The "path" of a dashboard must point to a JSON file.
       ## Use the "enabled" parameter to toggle a project or dashboard on or off. This optional parameter defaults to 'true'.
+      ## Use the optional "featureFlags" list to gate a project or dashboard on one or more global feature flags.
+      ## A dashboard is provisioned only when: enabled=true AND every listed feature flag is enabled under global.featureFlags.
       # some-project:
       #   enabled: false | true
       #   dashboards:
       #     some-dashboard:
       #      path: "dashboards/project/some-dashboard.json"
       #      enabled: false | true
+      #      featureFlags:
+      #        - someFlag
   # grafanaDatasourcesProvisioning:
     ## SystemLink enumerates all datasources in the datasource-configmap-template.yaml file.
     ## Each key under the "datasources" item will be the name of a datasource in the ConfigMap.
     ## By default, all "enabled" parameters are considered as true even if they are not mentioned. You can disable this by assigning "whitelistMode: true"
     # whitelistMode: false
     # projects:
-      ## Datasources must be grouped under projects
-      ## There is an optional "enabled" parameter that defaults to true which can be used to toggle the project/dashboard on or off.
+      ## Datasources must be grouped under projects.
+      ## There is an optional "enabled" parameter that defaults to true which can be used to toggle the project/datasource on or off.
+      ## There is an optional "featureFlags" list to gate a project or datasource on one or more global feature flags.
+      ## A datasource is provisioned only when: enabled=true AND every listed feature flag is enabled under global.featureFlags.
       # some-project:
       #   enabled: false | true
       #   datasources:
       #     some-datasource:
       #       enabled: false | true
+      #       featureFlags:
+      #         - someFlag
       #       name: Some Datasource
       #       type: some-datasource
       #       ## SystemLink copies each data source exactly as written into the template. To properly define an entry into the template, refer to the format as defined in the following link: https://github.com/grafana/helm-charts/blob/307aae1ba29039c4c80581d457299c0a126b55c1/charts/grafana/values.yaml#L458

--- a/getting-started/templates/systemlink-values.yaml
+++ b/getting-started/templates/systemlink-values.yaml
@@ -118,6 +118,18 @@ global:
   ## Deploy the certificate stored in apiHostCertificateSecret to all managed systems.
   ##
   deployApiHostCertificateToSystems: false
+  ##
+  ## Use the flags below to enable or disable optional SystemLink capabilities.
+  # featureFlags:
+    # <ATTENTION> - Set to false to disable the deployment of the work item and lab management UI services.
+    ##
+    # workitem: true
+    ##
+    # <ATTENTION> - Set to false to disable the Work Order APIs (work orders, test plans, test plan templates,
+    #               and workflows), their Grafana dashboards and datasources, and their Swagger API entries.
+    #               Has no effect unless global.featureFlags.workitem is also true.
+    ##
+    # workOrderApis: true
 
 ## Core configuration for the RabbitMQ message broker
 ##
@@ -1357,14 +1369,6 @@ comments:
   ## Maximum number of comments supported per delete comments request.
   ##
   maximumCommentsPerDeleteRequest: 1000
-
-## Configuration for work item service.
-##
-workitem:
-  ## <ATTENTION> - Set false to disable the deployment of the work item and lab management UI services.
-  ## By default, this is enabled and the work item and lab management UI services are deployed.
-  ##
-  enabled: true
 
 ## Configuration for specification management service.
 ##

--- a/getting-started/templates/systemlink-values.yaml
+++ b/getting-started/templates/systemlink-values.yaml
@@ -120,8 +120,9 @@ global:
   deployApiHostCertificateToSystems: false
   ##
   ## Use the flags below to enable or disable optional SystemLink capabilities.
+  ##
   # featureFlags:
-    # <ATTENTION> - Set to false to disable the deployment of the work item and lab management UI services.
+    # <ATTENTION> - Set to false to disable deployment of the work item and lab management UI services.
     ##
     # workitem: true
     ##


### PR DESCRIPTION
- [x] This contribution adheres to
      [CONTRIBUTING.md](https://github.com/ni/install-systemlink-enterprise/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Documents the new `global.featureFlags` mechanism for controlling optional SystemLink capabilities in the customer-facing values template, and removes obsolete Work Order sizing parameters following the Work Order to Work Item migration.

- Adds a commented-out `featureFlags` block under `global:` for `workitem` and `workOrderApis`, explaining when and how to set each flag to `false`. 
Refer [adr0059-global-feature-flag-registry.md](https://dev.azure.com/ni/DevCentral/_git/Skyline?path=%2Fdocs%2Farchitecture-decisions%2Fadr0059-global-feature-flag-registry.md&version=GBmaster&_a=preview) for more details.
- Removes the `workitem.enabled` field. The deployment condition for the Work Item and Lab Management UI services has moved to `global.featureFlags.workitem`. Operators who previously set `workitem.enabled: false` should now set `global.featureFlags.workitem: false`.
- Removes the Work Order sizing parameters (`maximumWorkOrdersPerCreateRequest`, `maximumTakePerQueryWorkOrdersRequest`, `maximumWorkOrdersPerUpdateRequest`, `maximumWorkOrdersPerDeleteRequest`) from the data management sizing example. Following the Work Order to Work Item migration, these parameters are no longer used; Work Orders now rely on the corresponding `maximumWorkItems*` parameters.

### Why should this Pull Request be merged?

- The `workitem.enabled` field no longer controls service deployment.  The replacement `global.featureFlags` block surfaces the correct toggle in the same values file, alongside a new `workOrderApis` flag that controls all deprecated Work Order API surface across the deployment.
- The Work Order sizing parameters have been removed because Work Orders are now represented as Work Items.

_Note: This change is made as part of 2026-07 SLE release._

### What testing has been done?

Manually verified the updated values file renders correctly.
