### PR TITLE
Adding DFS enablement toggles for the relevant grafana plugin and security UI roles

### DIFF
--- a/getting-started/templates/systemlink-values.yaml
+++ b/getting-started/templates/systemlink-values.yaml
@@ -891,7 +891,7 @@ dataframeservice:
 
 ## Grafana provisioning
 ##
-# grafanaprovisioning:
+grafanaprovisioning:
   # grafanaDashboardsProvisioning:
     ## Dashboards listed are enumerated over the dashboard-configmap-template.yaml
     ## Each key under the "dashboards" item will be the name of a ConfigMap.
@@ -914,12 +914,12 @@ dataframeservice:
       #      enabled: false | true
       #      featureFlags:
       #        - someFlag
-  # grafanaDatasourcesProvisioning:
+  grafanaDatasourcesProvisioning:
     ## SystemLink enumerates all datasources in the datasource-configmap-template.yaml file.
     ## Each key under the "datasources" item will be the name of a datasource in the ConfigMap.
     ## By default, all "enabled" parameters are considered as true even if they are not mentioned. You can disable this by assigning "whitelistMode: true"
     # whitelistMode: false
-    # projects:
+    projects:
       ## Datasources must be grouped under projects.
       ## There is an optional "enabled" parameter that defaults to true which can be used to toggle the project/datasource on or off.
       ## There is an optional "featureFlags" list to gate a project or datasource on one or more global feature flags.
@@ -935,6 +935,12 @@ dataframeservice:
       #       type: some-datasource
       #       ## SystemLink copies each data source exactly as written into the template. To properly define an entry into the template, refer to the format as defined in the following link: https://github.com/grafana/helm-charts/blob/307aae1ba29039c4c80581d457299c0a126b55c1/charts/grafana/values.yaml#L458
       #       ## Instead of a list of data sources, SystemLink uses key-pair values. You can define these values in the same way as Grafana.
+      systemlink:
+        datasources:
+          ## Provision these datasources only when every listed feature flag is enabled under
+          ## global.featureFlags. The grafanaprovisioning helper resolves the names below.
+          ni-sldataframe-datasource:
+            enabled: *dataframeserviceEnabled
 
 ## Salt configuration.
 ##

--- a/getting-started/templates/systemlink-values.yaml
+++ b/getting-started/templates/systemlink-values.yaml
@@ -682,53 +682,6 @@ dashboardhost:
         ##
         # allow_loading_unsigned_plugins: ni-systemlink-app
 
-## Grafana provisioning
-##
-# grafanaprovisioning:
-  # grafanaDashboardsProvisioning:
-    ## Dashboards listed are enumerated over the dashboard-configmap-template.yaml
-    ## Each key under the "dashboards" item will be the name of a ConfigMap.
-    ## NI recommends adding the "-dashboard" suffix to each key to avoid a name collision with other ConfigMaps.
-    ## You can place all Dashboard JSON files under the "dashboards/[project-name]/" file path.
-    ## By default, SystemLink considers all enabled parameters as 'true', even if a parameter is not in the JSON file. You can disable this setting by assigning the "whitelistMode" value to 'true'.
-    ##
-    # whitelistMode: false
-    # projects:
-      ## You must group all dashboards under a project.
-      ## The "path" of a dashboard must point to a JSON file.
-      ## Use the "enabled" parameter to toggle a project or dashboard on or off. This optional parameter defaults to 'true'.
-      ## Use the optional "featureFlags" list to gate a project or dashboard on one or more global feature flags.
-      ## A dashboard is provisioned only when: enabled=true AND every listed feature flag is enabled under global.featureFlags.
-      # some-project:
-      #   enabled: false | true
-      #   dashboards:
-      #     some-dashboard:
-      #      path: "dashboards/project/some-dashboard.json"
-      #      enabled: false | true
-      #      featureFlags:
-      #        - someFlag
-  # grafanaDatasourcesProvisioning:
-    ## SystemLink enumerates all datasources in the datasource-configmap-template.yaml file.
-    ## Each key under the "datasources" item will be the name of a datasource in the ConfigMap.
-    ## By default, all "enabled" parameters are considered as true even if they are not mentioned. You can disable this by assigning "whitelistMode: true"
-    # whitelistMode: false
-    # projects:
-      ## Datasources must be grouped under projects.
-      ## There is an optional "enabled" parameter that defaults to true which can be used to toggle the project/datasource on or off.
-      ## There is an optional "featureFlags" list to gate a project or datasource on one or more global feature flags.
-      ## A datasource is provisioned only when: enabled=true AND every listed feature flag is enabled under global.featureFlags.
-      # some-project:
-      #   enabled: false | true
-      #   datasources:
-      #     some-datasource:
-      #       enabled: false | true
-      #       featureFlags:
-      #         - someFlag
-      #       name: Some Datasource
-      #       type: some-datasource
-      #       ## SystemLink copies each data source exactly as written into the template. To properly define an entry into the template, refer to the format as defined in the following link: https://github.com/grafana/helm-charts/blob/307aae1ba29039c4c80581d457299c0a126b55c1/charts/grafana/values.yaml#L458
-      #       ## Instead of a list of data sources, SystemLink uses key-pair values. You can define these values in the same way as Grafana.
-
 ## Configuration for the Data Frame service.
 ##
 dataframeservice:
@@ -931,6 +884,53 @@ dataframeservice:
       # - SupportsAppend
       # - MetadataModifiedAt
       # - MetadataRevision
+
+## Grafana provisioning
+##
+# grafanaprovisioning:
+  # grafanaDashboardsProvisioning:
+    ## Dashboards listed are enumerated over the dashboard-configmap-template.yaml
+    ## Each key under the "dashboards" item will be the name of a ConfigMap.
+    ## NI recommends adding the "-dashboard" suffix to each key to avoid a name collision with other ConfigMaps.
+    ## You can place all Dashboard JSON files under the "dashboards/[project-name]/" file path.
+    ## By default, SystemLink considers all enabled parameters as 'true', even if a parameter is not in the JSON file. You can disable this setting by assigning the "whitelistMode" value to 'true'.
+    ##
+    # whitelistMode: false
+    # projects:
+      ## You must group all dashboards under a project.
+      ## The "path" of a dashboard must point to a JSON file.
+      ## Use the "enabled" parameter to toggle a project or dashboard on or off. This optional parameter defaults to 'true'.
+      ## Use the optional "featureFlags" list to gate a project or dashboard on one or more global feature flags.
+      ## A dashboard is provisioned only when: enabled=true AND every listed feature flag is enabled under global.featureFlags.
+      # some-project:
+      #   enabled: false | true
+      #   dashboards:
+      #     some-dashboard:
+      #      path: "dashboards/project/some-dashboard.json"
+      #      enabled: false | true
+      #      featureFlags:
+      #        - someFlag
+  # grafanaDatasourcesProvisioning:
+    ## SystemLink enumerates all datasources in the datasource-configmap-template.yaml file.
+    ## Each key under the "datasources" item will be the name of a datasource in the ConfigMap.
+    ## By default, all "enabled" parameters are considered as true even if they are not mentioned. You can disable this by assigning "whitelistMode: true"
+    # whitelistMode: false
+    # projects:
+      ## Datasources must be grouped under projects.
+      ## There is an optional "enabled" parameter that defaults to true which can be used to toggle the project/datasource on or off.
+      ## There is an optional "featureFlags" list to gate a project or datasource on one or more global feature flags.
+      ## A datasource is provisioned only when: enabled=true AND every listed feature flag is enabled under global.featureFlags.
+      # some-project:
+      #   enabled: false | true
+      #   datasources:
+      #     some-datasource:
+      #       enabled: false | true
+      #       featureFlags:
+      #         - someFlag
+      #       name: Some Datasource
+      #       type: some-datasource
+      #       ## SystemLink copies each data source exactly as written into the template. To properly define an entry into the template, refer to the format as defined in the following link: https://github.com/grafana/helm-charts/blob/307aae1ba29039c4c80581d457299c0a126b55c1/charts/grafana/values.yaml#L458
+      #       ## Instead of a list of data sources, SystemLink uses key-pair values. You can define these values in the same way as Grafana.
 
 ## Salt configuration.
 ##

--- a/getting-started/templates/systemlink-values.yaml
+++ b/getting-started/templates/systemlink-values.yaml
@@ -685,6 +685,10 @@ dashboardhost:
 ## Configuration for the Data Frame service.
 ##
 dataframeservice:
+  ## Set true to enable the deployment of the DataFrame service.
+  ## By default, this is enabled and the DataFrame service is deployed.
+  enabled: &dataframeserviceEnabled true
+
   ## Ingress configuration
   ##
   ingress:

--- a/getting-started/templates/systemlink-values.yaml
+++ b/getting-started/templates/systemlink-values.yaml
@@ -1416,6 +1416,9 @@ serviceregistry:
       specification:
         ## Add the "Specification" service to the service registry if enabled
         enabled: *specificationManagementEnabled
+  privilegeToggles:
+    ## Show or hide the option to set security privileges for data frame service
+    dataframe: *dataframeserviceEnabled
 
 ## Configuration for dynamic form fields.
 ##


### PR DESCRIPTION
- [x] This contribution adheres to
      [CONTRIBUTING.md](https://github.com/ni/install-systemlink-enterprise/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

We want to show the following only if DataFrame service is enabled:
* the relevant Grafana plugin
* the ability to edit the relevant security privileges in the UI

Additional notes:
* I moved the grafana provisioning section below dataframeservice so that it could pick up the new setting
* This is the old way of doing things. We have a new feature flag system, and this will be updated with such for next release.
* This PR replaces https://github.com/ni/install-systemlink-enterprise/pull/337

### Why should this Pull Request be merged?

To make sure those using the systemlink-values template don't miss this setting. See [AB#3916389](https://dev.azure.com/ni/DevCentral/_workitems/edit/3937058).

### What testing has been done?

Testing was done as part of the original AzDO PR.