### PR TITLE
Remove webserver.secrets.encryptionKey from template

### DIFF
--- a/getting-started/templates/systemlink-secrets.yaml
+++ b/getting-started/templates/systemlink-secrets.yaml
@@ -59,9 +59,6 @@ secrets:
 ##
 webserver:
   secrets:
-    ## This AES-128 key encrypts session data. Ensure the key is 16 bytes long.
-    ##
-    encryptionKey: "" # <ATTENTION>
     ## This SHA-256 key cryptographically signs session data. Ensure this key has a length between 32 and 64 bytes.
     ##
     signatureKey: "" # <ATTENTION>


### PR DESCRIPTION
- [x] This contribution adheres to
      [CONTRIBUTING.md](https://github.com/ni/install-systemlink-enterprise/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

The encryptionKey value is unreferenced and does not need to be included in the template.

### Why should this Pull Request be merged?

Template cleanup.

### What testing has been done?

N/A
